### PR TITLE
Example of Redis session cache for horizontally scaled httpd

### DIFF
--- a/openidc-jessie/000-default.conf
+++ b/openidc-jessie/000-default.conf
@@ -14,6 +14,9 @@
 
 	OIDCSessionType server-cache:persistent
 
+	OIDCCacheType redis
+	OIDCRedisCacheServer redis1
+
 	OIDCRemoteUserClaim email
 	OIDCScope "openid email"
 	OIDCPassClaimsAs environment

--- a/openidc1/docker-compose.yml
+++ b/openidc1/docker-compose.yml
@@ -53,6 +53,18 @@ services:
       - keycloak
     volumes:
       - ./html-ajax:/var/www/html
+  # Can be used to test that auth state is shared between containers,
+  # but login on http://openidc:2080/ will redirect to the wrong instance unless we tweak the conf file
+  openidc2:
+    build: ../openidc-jessie
+    ports:
+      - "2080:80"
+    links:
+      - redis1:redis
+    depends_on:
+      - keycloak
+    volumes:
+      - ./html-ajax:/var/www/html
   keycloak-setup:
     build: ./keycloak-setup
     links:

--- a/openidc1/docker-compose.yml
+++ b/openidc1/docker-compose.yml
@@ -34,6 +34,10 @@ services:
     #  - -Dkeycloak.migration.action=export
     #  - -Dkeycloak.migration.provider=dir
     #  - -Dkeycloak.migration.dir=/export
+  redis1:
+    image: redis
+    expose:
+      - "6379"
   openidc:
     build: ../openidc-jessie
     expose:
@@ -41,11 +45,12 @@ services:
     # For local browser; you also need "openidc" in your hosts file
     ports:
       - "80:80"
+    links:
+      - redis1:redis
+      # Commented out to disallow direct communication with keycloak; depends on hosting scenario
+      #- keycloak
     depends_on:
       - keycloak
-    # Don't allow direct communication with keycloak; depends on hosting scenario
-    #links:
-    #  - keycloak
     volumes:
       - ./html-ajax:/var/www/html
   keycloak-setup:

--- a/openidc1/docker-compose.yml
+++ b/openidc1/docker-compose.yml
@@ -55,14 +55,16 @@ services:
       - ./html-ajax:/var/www/html
   # Can be used to test that auth state is shared between containers,
   # but login on http://openidc:2080/ will redirect to the wrong instance unless we tweak the conf file
+  redis2:
+    image: redis
+    expose:
+      - "6379"
   openidc2:
     build: ../openidc-jessie
     ports:
       - "2080:80"
     links:
-      - redis1:redis
-    depends_on:
-      - keycloak
+      - redis2:redis
     volumes:
       - ./html-ajax:/var/www/html
   keycloak-setup:

--- a/openidc1/docker-compose.yml
+++ b/openidc1/docker-compose.yml
@@ -53,18 +53,12 @@ services:
       - keycloak
     volumes:
       - ./html-ajax:/var/www/html
-  # Can be used to test that auth state is shared between containers,
-  # but login on http://openidc:2080/ will redirect to the wrong instance unless we tweak the conf file
-  redis2:
-    image: redis
-    expose:
-      - "6379"
   openidc2:
     build: ../openidc-jessie
     ports:
       - "2080:80"
     links:
-      - redis2:redis
+      - redis1:redis
     volumes:
       - ./html-ajax:/var/www/html
   keycloak-setup:

--- a/openidc1/html-ajax/protected/index.html
+++ b/openidc1/html-ajax/protected/index.html
@@ -17,7 +17,7 @@
     <ul id="log">
     </ul>
     <p>If you're running shared state with a second container,
-      you're now also authenticated at <a href="http://openidc:2080/">http://openidc:2080/</a>
+      you're now also authenticated at <a href="http://openidc:2080/protected/">http://openidc:2080/protected/</a>
       without any extra keycloak roundtrips.
     </p>
     <!-- page content -->

--- a/openidc1/html-ajax/protected/index.html
+++ b/openidc1/html-ajax/protected/index.html
@@ -14,7 +14,12 @@
         Log out
       </a>.
     <p>
-    <ul id="log"/>
+    <ul id="log">
+    </ul>
+    <p>If you're running shared state with a second container,
+      you're now also authenticated at <a href="http://openidc:2080/">http://openidc:2080/</a>
+      without any extra keycloak roundtrips.
+    </p>
     <!-- page content -->
   </body>
 </html>

--- a/openidc1/html-ajax/protected/script.js
+++ b/openidc1/html-ajax/protected/script.js
@@ -1,4 +1,7 @@
 
+// Note that jQuery sends X-Requested-With but other AJAX libs might not
+// so see https://github.com/pingidentity/mod_auth_openidc/wiki/Cookies
+
 var ajaxtestGET = function(log) {
   $.ajax({
     url: '/protected/'


### PR DESCRIPTION
Demonstrates how multiple Apache httpd containers can share mod_auth_openidc session state using redis. The default, shm, only works for single container.
