### PR TITLE
Build an example logout URL and place it near the OIDCRedirectURI config

### DIFF
--- a/openidc-jessie/000-default.conf
+++ b/openidc-jessie/000-default.conf
@@ -20,20 +20,7 @@
 
 	Header setifempty Cache-Control "max-age=0, must-revalidate"
 
-	# This is Keycloak's logout URL, see http://keycloak.github.io/docs/userguide/keycloak-server/html/ch08.html#d4e1398
-	# with, as redirect_uri, the urlencoded OIDCRedirectURI from above
-	# with ?logout=[final destination], also urlencoded so look for "%3F".
-	# And if you want a query param for the destination page it's even more encoding...
-	# See https://github.com/pingidentity/mod_auth_openidc/wiki#9-how-do-i-logout-users
-	# Using a temp redirect so we can trust we get an apache log entry for every logout
-	# This is non-trivial so we keep all the stages of encoding as documentation
-	#RedirectTemp /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http://openidc/protected/redirect_uri?logout=            http://openidc/?we-have-no-loggedout-page-yet
-	#RedirectTemp /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%3A%2F%2Fopenidc%2F%3Fwe-have-no-loggedout-page-yet
-	#RedirectTemp  /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%253A%252F%252Fopenidc%252F%253Fwe-have-no-loggedout-page-yet
-	# Actually because OIDCProviderMetadataURL declares an end_session_endpoint it should be the other way around
-	#RedirectTemp /logout http://openidc/protected/redirect_uri?logout=http://openidc/?we-have-no-loggedout-page-yet
 	RedirectTemp /logout http://openidc/protected/redirect_uri?logout=http%3A%2F%2Fopenidc%2F%3Fwe-have-no-loggedout-page-yet
-	# TODO test if redirect should be changed to strip anything after /logout
 
 	<Location /protected>
 		AuthType openid-connect

--- a/openidc-jessie/000-default.conf
+++ b/openidc-jessie/000-default.conf
@@ -29,7 +29,11 @@
 	# This is non-trivial so we keep all the stages of encoding as documentation
 	#RedirectTemp /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http://openidc/protected/redirect_uri?logout=            http://openidc/?we-have-no-loggedout-page-yet
 	#RedirectTemp /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%3A%2F%2Fopenidc%2F%3Fwe-have-no-loggedout-page-yet
-	RedirectTemp  /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%253A%252F%252Fopenidc%252F%253Fwe-have-no-loggedout-page-yet
+	#RedirectTemp  /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%253A%252F%252Fopenidc%252F%253Fwe-have-no-loggedout-page-yet
+	# Actually because OIDCProviderMetadataURL declares an end_session_endpoint it should be the other way around
+	#RedirectTemp /logout http://openidc/protected/redirect_uri?logout=http://openidc/?we-have-no-loggedout-page-yet
+	RedirectTemp /logout http://openidc/protected/redirect_uri?logout=http%3A%2F%2Fopenidc%2F%3Fwe-have-no-loggedout-page-yet
+	# TODO test if redirect should be changed to strip anything after /logout
 
 	<Location /protected>
 		AuthType openid-connect

--- a/openidc-jessie/000-default.conf
+++ b/openidc-jessie/000-default.conf
@@ -20,6 +20,17 @@
 
 	Header setifempty Cache-Control "max-age=0, must-revalidate"
 
+	# This is Keycloak's logout URL, see http://keycloak.github.io/docs/userguide/keycloak-server/html/ch08.html#d4e1398
+	# with, as redirect_uri, the urlencoded OIDCRedirectURI from above
+	# with ?logout=[final destination], also urlencoded so look for "%3F".
+	# And if you want a query param for the destination page it's even more encoding...
+	# See https://github.com/pingidentity/mod_auth_openidc/wiki#9-how-do-i-logout-users
+	# Using a temp redirect so we can trust we get an apache log entry for every logout
+	# This is non-trivial so we keep all the stages of encoding as documentation
+	#RedirectTemp /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http://openidc/protected/redirect_uri?logout=            http://openidc/?we-have-no-loggedout-page-yet
+	#RedirectTemp /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%3A%2F%2Fopenidc%2F%3Fwe-have-no-loggedout-page-yet
+	RedirectTemp  /logout http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Fopenidc%2Fprotected%2Fredirect_uri%3Flogout=http%253A%252F%252Fopenidc%252F%253Fwe-have-no-loggedout-page-yet
+
 	<Location /protected>
 		AuthType openid-connect
 		Require valid-user

--- a/openidc1/html-ajax/protected/index.html
+++ b/openidc1/html-ajax/protected/index.html
@@ -10,7 +10,7 @@
   <body>
     <h1>Protected page</h1>
     <p>You're authenticated.
-      <a href="http://keycloak:8080/auth/realms/Testrealm/protocol/openid-connect/logout?redirect_uri=http://openidc">
+      <a href="/logout">
         Log out
       </a>.
     <p>


### PR DESCRIPTION
To address #1.

I dont think this kind of internal details should be left to the UI layer, so I added the special URL `/logout`.