### PR TITLE
Support login from bookmarked URL

### DIFF
--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -8,7 +8,7 @@
 	OIDCProviderMetadataURL http://keycloak:8080/auth/realms/Testrealm/.well-known/openid-configuration
 	#OIDCRedirectURI http://openidc/oauth2callback
 	OIDCRedirectURI http://openidc/protected/redirect_uri
-	OIDCDefaultURL http://openidc/
+	OIDCDefaultURL http://openidc/protected/
 	OIDCCryptoPassphrase 0123456789
 	OIDCClientID testclient
 	OIDCClientSecret 12816dc7-cf40-4abc-8df7-581e56930cf5

--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -8,6 +8,7 @@
 	OIDCProviderMetadataURL http://keycloak:8080/auth/realms/Testrealm/.well-known/openid-configuration
 	#OIDCRedirectURI http://openidc/oauth2callback
 	OIDCRedirectURI http://openidc/protected/redirect_uri
+	OIDCDefaultURL http://openidc/
 	OIDCCryptoPassphrase 0123456789
 	OIDCClientID testclient
 	OIDCClientSecret 12816dc7-cf40-4abc-8df7-581e56930cf5


### PR DESCRIPTION
Fixes #10.

Users frequently bookmark the login url, instead of the startpage URL.

Now logs look quite like in #10 but with "a default SSO URL is set, sending the user there".