### PR TITLE
Use Keycloak's account UUID as user identifier

### DIFF
--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -15,7 +15,7 @@
 
 	OIDCSessionType server-cache:persistent
 
-	OIDCRemoteUserClaim email
+	OIDCRemoteUserClaim sub
 	OIDCScope "openid email"
 	OIDCPassClaimsAs environment
 


### PR DESCRIPTION
 * Users may change e-mail address
 * WRT privacy standards the UUID anonymizes the user