### PR TITLE
Use mod_auth_openidc 2.2+ with session info and access type public

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [docker-compose.yml](https://github.com/Reposoft/openidc-keycloak-test/blob/
 Might be run like this:
 ```
 compose="docker-compose -f build-contracts/docker-compose.yml"
-$compose up --build -d mysql keycloak openidc
+$compose up --build -d postgres keycloak openidc
 $compose up --build keycloak-setup #TODO
 $compose up --build -d testclient
 $compose logs -f

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [docker-compose.yml](https://github.com/Reposoft/openidc-keycloak-test/blob/
 Might be run like this:
 ```
 compose="docker-compose -f build-contracts/docker-compose.yml"
-$compose up --build -d postgres keycloak openidc
+$compose up --build -d mysql keycloak openidc
 $compose up --build keycloak-setup #TODO
 $compose up --build -d testclient
 $compose logs -f

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Demonstrates [Keycloak](http://keycloak.jboss.org/) and [mod_auth_openidc](https
 Requirements:
  * Docker Compose >=1.7.0
 
-See [docker-compose.yml](https://github.com/Reposoft/openidc-keycloak-test/blob/master/build-contracts/docker-compose.yml) in the [openidc1](https://github.com/Reposoft/openidc-keycloak-test/tree/master/build-contracts) folder.
+See [docker-compose.yml](https://github.com/Reposoft/openidc-keycloak-test/blob/master/build-contracts/docker-compose.yml) in the [build-contracts](https://github.com/Reposoft/openidc-keycloak-test/tree/master/build-contracts) folder.
 
 Might be run like this:
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Until setup is fully automated see echo:s in [testclient1/keycloak-setup/import.
 
 If you can access `ports` locally, access the example site at http://openidc/, with something like this in `/etc/hosts` (IP being you docker machine's):
 ```
-127.0.0.1 keycloak
 127.0.0.1 openidc
+```
+
+Direct access to keycloak is at :8080. Auth should understand proxy, according to:
+ * https://github.com/jboss-dockerfiles/keycloak/tree/master/server#enabling-proxy-address-forwarding
+ * https://docs.jboss.org/author/display/WFLY8/Undertow+subsystem+configuration#Undertowsubsystemconfiguration-HTTPConnector
+
+## Export and import
+
+Export [seems to](https://keycloak.gitbooks.io/documentation/server_admin/topics/export-import.html) require restart.
+```
+docker-compose -f build-contracts/docker-compose.yml -f build-contracts/export.docker-compose.yml up keycloak
 ```

--- a/build-contracts/client-node-request/Dockerfile
+++ b/build-contracts/client-node-request/Dockerfile
@@ -1,4 +1,4 @@
 
-FROM solsson/node:6-run
+FROM solsson/node:7-run
 
 ADD app /usr/src/app

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -1,32 +1,25 @@
 version: '2'
 services:
-  mysql:
-    image: mariadb:10.1.23
+  postgres:
+    image: postgres:9.6
     expose:
-      - "3306"
+      - "5432"
     environment:
-      MYSQL_ROOT_PASSWORD: openidctest
-      MYSQL_DATABASE: keycloak
-      MYSQL_USER: keycloak
-      MYSQL_PASSWORD: keycloak
-    command:
-      # https://issues.jboss.org/browse/KEYCLOAK-3873
-      - --character-set-server=utf8
-      - --collation-server=utf8_unicode_ci
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
   keycloak:
-    image: jboss/keycloak-mysql:3.1.0.Final
+    image: jboss/keycloak-postgres:3.1.0.Final
     links:
-      - mysql
+      - postgres
     environment:
+      PROXY_ADDRESS_FORWARDING: "true"
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: openidctest
-      MYSQL_USERNAME: keycloak
-      MYSQL_PASSWORD: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
       # Workaround for container using legacy Docker links, resulting in
-      # "WFLYCTL0211: Cannot resolve expression 'jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}
-      MYSQL_PORT_3306_TCP_ADDR: mysql
-      MYSQL_PORT_3306_TCP_PORT: "3306"
-      PROXY_ADDRESS_FORWARDING: "true"
+      # "WFLYCTL0211: Cannot resolve expression 'jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}...")n
+      POSTGRES_PORT_5432_TCP_ADDR: postgres
     expose:
       - "8080"
       - "9090"

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -14,13 +14,13 @@ services:
       - --character-set-server=utf8
       - --collation-server=utf8_unicode_ci
   keycloak:
-    image: jboss/keycloak-mysql:2.5.5.Final
+    image: jboss/keycloak-mysql:3.1.0.Final
     links:
       - mysql
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: openidctest
-      MYSQL_USER: keycloak
+      MYSQL_USERNAME: keycloak
       MYSQL_PASSWORD: keycloak
       # Workaround for container using legacy Docker links, resulting in
       # "WFLYCTL0211: Cannot resolve expression 'jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -1,24 +1,31 @@
 version: '2'
 services:
-  postgres:
-    image: postgres:9.6
+  mysql:
+    image: mariadb:10.1.23
     expose:
-      - "5432"
+      - "3306"
     environment:
-      POSTGRES_USER: keycloak
-      POSTGRES_PASSWORD: keycloak
+      MYSQL_ROOT_PASSWORD: openidctest
+      MYSQL_DATABASE: keycloak
+      MYSQL_USER: keycloak
+      MYSQL_PASSWORD: keycloak
+    command:
+      # https://issues.jboss.org/browse/KEYCLOAK-3873
+      - --character-set-server=utf8
+      - --collation-server=utf8_unicode_ci
   keycloak:
-    image: jboss/keycloak-postgres:2.4.0.Final
+    image: jboss/keycloak-mysql:2.5.5.Final
     links:
-      - postgres
+      - mysql
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: openidctest
-      POSTGRES_USER: keycloak
-      POSTGRES_PASSWORD: keycloak
+      MYSQL_USER: keycloak
+      MYSQL_PASSWORD: keycloak
       # Workaround for container using legacy Docker links, resulting in
-      # "WFLYCTL0211: Cannot resolve expression 'jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}...")n
-      POSTGRES_PORT_5432_TCP_ADDR: postgres
+      # "WFLYCTL0211: Cannot resolve expression 'jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}
+      MYSQL_PORT_3306_TCP_ADDR: mysql
+      MYSQL_PORT_3306_TCP_PORT: "3306"
     expose:
       - "8080"
       - "9090"

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       # "WFLYCTL0211: Cannot resolve expression 'jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}
       MYSQL_PORT_3306_TCP_ADDR: mysql
       MYSQL_PORT_3306_TCP_PORT: "3306"
+      PROXY_ADDRESS_FORWARDING: "true"
     expose:
       - "8080"
       - "9090"
@@ -33,14 +34,6 @@ services:
     ports:
       - "8080:8080"
       - "9990:9990"
-    # Uncomment the following and docker-compose up keycloak again to export realms
-    volumes:
-      - ./keycloak-setup/export:/export
-    #entrypoint:
-    #  - /opt/jboss/keycloak/bin/standalone.sh
-    #  - -Dkeycloak.migration.action=export
-    #  - -Dkeycloak.migration.provider=dir
-    #  - -Dkeycloak.migration.dir=/export
   httpd-openidc:
     build: ../httpd-openidc
     image: localhost:5000/reposoft/httpd-openidc

--- a/build-contracts/export.docker-compose.yml
+++ b/build-contracts/export.docker-compose.yml
@@ -1,0 +1,11 @@
+# use as additional -f with docker-compose to trigger export
+version: '2'
+services:
+  keycloak:
+    volumes:
+      - ./keycloak-setup/export:/export
+    entrypoint:
+      - /opt/jboss/keycloak/bin/standalone.sh
+      - -Dkeycloak.migration.action=export
+      - -Dkeycloak.migration.provider=dir
+      - -Dkeycloak.migration.dir=/export

--- a/build-contracts/html-ajax/index.html
+++ b/build-contracts/html-ajax/index.html
@@ -8,12 +8,12 @@
     <h2>Initial setup</h2>
     <p>
       You need to import a testing realm into Keycloak.
-      Login at <a href="http://keycloak:8080/">http://keycloak:8080/</a>
+      Login at <a href="http://openidc:8080/">http://openidc:8080/</a>
       (URL depends on your hosts file) using <code>admin:openidctest</code>.
-      In <a href="http://keycloak:8080/auth/admin/master/console/#/create/realm">create realm</a>
+      In <a href="http://openidc:8080/auth/admin/master/console/#/create/realm">create realm</a>
       use the file Testrealm-realm.json from <code>keycloak-setup/exports</code>.
       Then import Testrealm-users-0.json as
-      <a href="http://keycloak:8080/auth/admin/master/console/#/realms/Testrealm/partial-import">Partial import</a>.
+      <a href="http://openidc:8080/auth/admin/master/console/#/realms/Testrealm/partial-import">Partial import</a>.
     </p>
     <h2>Auth testing</h2>
     <p>Go to <a href="/protected">/protected</a> to log in.</p>

--- a/build-contracts/html-ajax/protected/index.html
+++ b/build-contracts/html-ajax/protected/index.html
@@ -14,7 +14,10 @@
         Log out
       </a>.
     <p>
-    <p>See <a href="cgi/printenv">environment variables</a></p>
+    <p>
+      See <a href="cgi/printenv">environment variables</a>
+      and <a href="/protected/redirect_uri?info=json">session info</a>
+    </p>
     <ul id="log"/>
     <!-- page content -->
   </body>

--- a/build-contracts/keycloak-setup/export/Testrealm-realm.json
+++ b/build-contracts/keycloak-setup/export/Testrealm-realm.json
@@ -5,8 +5,8 @@
   "revokeRefreshToken" : false,
   "accessTokenLifespan" : 300,
   "accessTokenLifespanForImplicitFlow" : 900,
-  "ssoSessionIdleTimeout" : 1800,
-  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeout" : 60,
+  "ssoSessionMaxLifespan" : 120,
   "offlineSessionIdleTimeout" : 2592000,
   "accessCodeLifespan" : 60,
   "accessCodeLifespanUserAction" : 300,
@@ -17,6 +17,8 @@
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,
   "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
   "resetPasswordAllowed" : false,
   "editUsernameAllowed" : false,
   "bruteForceProtected" : false,
@@ -28,182 +30,195 @@
   "failureFactor" : 30,
   "roles" : {
     "realm" : [ {
-      "id" : "af2ea597-6832-4488-8f1e-08ec43044d80",
-      "name" : "uma_authorization",
-      "description" : "${role_uma_authorization}",
-      "scopeParamRequired" : false,
-      "composite" : false,
-      "clientRole" : false,
-      "containerId" : "Testrealm"
-    }, {
-      "id" : "1189c8e1-ae01-490c-a61c-f535b1b263c5",
+      "id" : "fa489239-688f-456d-b4fb-a91b3b31ece0",
       "name" : "offline_access",
       "description" : "${role_offline-access}",
       "scopeParamRequired" : true,
       "composite" : false,
       "clientRole" : false,
       "containerId" : "Testrealm"
+    }, {
+      "id" : "203e0e06-6a3a-4054-8e40-8d68adac544f",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "scopeParamRequired" : false,
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "Testrealm"
     } ],
     "client" : {
       "realm-management" : [ {
-        "id" : "a89afbc4-8e92-42a1-9206-9465b44430ee",
-        "name" : "impersonation",
-        "description" : "${role_impersonation}",
+        "id" : "9e98d17b-3368-4bd9-b0cc-75dbe823fbc5",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       }, {
-        "id" : "5ba63535-da39-48fa-82b6-1f8f6a75f02d",
-        "name" : "manage-users",
-        "description" : "${role_manage-users}",
+        "id" : "00e4879f-067e-46a2-952d-b87998ead879",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       }, {
-        "id" : "6a158ed8-173e-40c8-a1cb-b46cee17f132",
-        "name" : "view-identity-providers",
-        "description" : "${role_view-identity-providers}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "a2060020-021e-4d08-9779-f263490416d3",
-        "name" : "view-clients",
-        "description" : "${role_view-clients}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "bcda8189-8ed4-4702-a730-1ef47fc66c13",
-        "name" : "manage-authorization",
-        "description" : "${role_manage-authorization}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "569433b7-b196-436e-94d6-14294e941898",
+        "id" : "683a633e-09fe-4c3f-88a7-2f050d851af7",
         "name" : "realm-admin",
         "description" : "${role_realm-admin}",
         "scopeParamRequired" : false,
         "composite" : true,
         "composites" : {
           "client" : {
-            "realm-management" : [ "impersonation", "manage-users", "view-identity-providers", "view-clients", "manage-authorization", "view-users", "manage-identity-providers", "manage-events", "create-client", "view-realm", "view-events", "manage-clients", "view-authorization", "manage-realm" ]
+            "realm-management" : [ "create-client", "manage-clients", "view-events", "view-realm", "impersonation", "manage-users", "view-clients", "view-users", "manage-identity-providers", "view-authorization", "manage-authorization", "view-identity-providers", "manage-events", "manage-realm" ]
           }
         },
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       }, {
-        "id" : "0c5aafcf-129d-4e94-9bd1-ddfcaf93608a",
-        "name" : "view-users",
-        "description" : "${role_view-users}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "6441603c-399c-4fba-be63-e60c3bb8cdda",
-        "name" : "manage-identity-providers",
-        "description" : "${role_manage-identity-providers}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "6b0f16e9-484b-4290-a514-17816106f2e2",
-        "name" : "manage-events",
-        "description" : "${role_manage-events}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "f2bd351c-df15-4f9d-9a46-690a44247812",
-        "name" : "create-client",
-        "description" : "${role_create-client}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "57e0bb65-4db3-4d02-a621-184868fa3584",
-        "name" : "view-realm",
-        "description" : "${role_view-realm}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
-      }, {
-        "id" : "88dd4c8f-76e0-496e-908e-a4c634e934a2",
+        "id" : "e129c4f4-0460-4f77-829f-734bfa87ed44",
         "name" : "view-events",
         "description" : "${role_view-events}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       }, {
-        "id" : "a60085cc-11cd-4ede-a579-5af18d3923c4",
-        "name" : "manage-clients",
-        "description" : "${role_manage-clients}",
+        "id" : "2055781b-c6d1-42fd-9c07-bc9b6f5d2502",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       }, {
-        "id" : "7c846ebc-50c9-4e64-97d4-617aa1be484d",
+        "id" : "0794373f-7365-4bd0-abc2-dbd5304cd247",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "580a9785-0af3-4394-92ce-e3dfadef997a",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "d0d64de5-cebe-46b5-871f-5d840961c741",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "76a33f24-63d5-4889-bc3a-2eb0568e6363",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "a0278142-9628-47ce-914a-d11cafea8c5c",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "74277c47-b149-4924-aa78-168bb26745c3",
         "name" : "view-authorization",
         "description" : "${role_view-authorization}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       }, {
-        "id" : "df287f24-f9e3-4545-9474-2c4403dbe7fe",
+        "id" : "5f4c9217-5066-4a98-b3c9-7757b05f8d53",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "ae31e872-2436-4c65-89ca-d42724f92ac7",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "8aea41ce-6e0d-417f-b667-9b338a0d7ea6",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
+      }, {
+        "id" : "b3d8fe84-1b41-4d26-b253-2d60d62282f0",
         "name" : "manage-realm",
         "description" : "${role_manage-realm}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "f2038460-cf26-454d-aacb-4e640d4e0b41"
+        "containerId" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153"
       } ],
       "security-admin-console" : [ ],
       "admin-cli" : [ ],
-      "testclient" : [ ],
+      "openid1" : [ ],
       "broker" : [ {
-        "id" : "2f657cc6-eed4-4deb-bae2-e1485a74b69f",
+        "id" : "cb9e6099-9bb9-40ae-882e-a6db2b7dae02",
         "name" : "read-token",
         "description" : "${role_read-token}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "5f6dc762-3779-4173-a3f9-eec981f2ddb2"
+        "containerId" : "8cbf2d17-8141-4575-8df1-31448b20c3a0"
       } ],
       "account" : [ {
-        "id" : "273cbc2b-344e-452f-b275-72f8cefb2461",
-        "name" : "manage-account",
-        "description" : "${role_manage-account}",
+        "id" : "141039f5-5677-48ce-9f74-d005d8d10717",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "597686b0-8db3-4534-8c46-62415843c604"
+        "containerId" : "799b8ff2-0d7e-4079-8bad-aa3431568b87"
       }, {
-        "id" : "1aa390ad-8fbc-4709-9f7f-d827123a78e2",
+        "id" : "ad7892da-b1b1-4917-a427-3d92588c2bd2",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "scopeParamRequired" : false,
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "799b8ff2-0d7e-4079-8bad-aa3431568b87"
+      }, {
+        "id" : "d851f3b0-c323-46f2-9574-bac19a724d11",
         "name" : "view-profile",
         "description" : "${role_view-profile}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "597686b0-8db3-4534-8c46-62415843c604"
+        "containerId" : "799b8ff2-0d7e-4079-8bad-aa3431568b87"
       } ]
     }
   },
   "groups" : [ ],
-  "defaultRoles" : [ "offline_access", "uma_authorization" ],
+  "defaultRoles" : [ "uma_authorization", "offline_access" ],
   "requiredCredentials" : [ "password" ],
   "passwordPolicy" : "hashIterations(20000)",
   "otpPolicyType" : "totp",
@@ -222,15 +237,15 @@
     } ]
   },
   "clients" : [ {
-    "id" : "597686b0-8db3-4534-8c46-62415843c604",
+    "id" : "799b8ff2-0d7e-4079-8bad-aa3431568b87",
     "clientId" : "account",
     "name" : "${client_account}",
     "baseUrl" : "/auth/realms/Testrealm/account",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "c2818174-e1a4-41bc-b556-367b69b02309",
-    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "secret" : "b08a22ff-3219-4f03-b88c-7e102a352c24",
+    "defaultRoles" : [ "manage-account", "view-profile" ],
     "redirectUris" : [ "/auth/realms/Testrealm/account/*" ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -242,11 +257,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : false,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "a8efdc26-8480-4d05-a9f4-84649f118c40",
+      "id" : "e243c34d-de3d-4d21-bb08-5af512d1842b",
       "name" : "full name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-full-name-mapper",
@@ -257,33 +273,7 @@
         "access.token.claim" : "true"
       }
     }, {
-      "id" : "3453f4b2-ed52-4a8b-86b6-e9fd27a10d6d",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "bc79ffc8-5a46-40b9-ab8b-7b785028fd83",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "d1d2fab8-fa01-43a5-a18d-11754e9b7e8e",
+      "id" : "91153bf6-abc2-4750-b7b6-61fd804fe04a",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -298,7 +288,22 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "d7dd69c5-e3d0-4a19-bcde-fdfec443bd53",
+      "id" : "7da40a9e-3d89-4008-a884-b79deb489682",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b6fe1e2d-912e-4432-b75e-73181c5dde22",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -313,32 +318,43 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "ef9f603f-357c-41d0-b3c3-b3a6f44ebae1",
-      "name" : "family name",
+      "id" : "c01821f8-d99f-451d-9138-4c0636318574",
+      "name" : "username",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
       "consentRequired" : true,
-      "consentText" : "${familyName}",
+      "consentText" : "${username}",
       "config" : {
         "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
+        "user.attribute" : "username",
         "id.token.claim" : "true",
         "access.token.claim" : "true",
-        "claim.name" : "family_name",
+        "claim.name" : "preferred_username",
         "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f2fed4d0-fe56-4b83-9696-cfca6fe00950",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
       }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "bd878ae3-aae9-4611-af86-3fb3df0c4dd2",
+    "id" : "53f650c6-0fe7-4d08-b9f0-85a96d79510b",
     "clientId" : "admin-cli",
     "name" : "${client_admin-cli}",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "c0f8a7ca-c18c-4797-8ec6-051cd4cac3d1",
+    "secret" : "0b7187b6-2d08-4b73-8f99-43bf22038f0a",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -350,11 +366,23 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : true,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "fb7e5d6a-c20f-4c76-9205-e941febd31f7",
+      "id" : "a0eba6a1-16b0-45d6-8ffc-15369a331d87",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "bf0cd11f-641e-4b89-b90e-4547527e9d2b",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -369,7 +397,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "e1a6c58a-dcd9-4e4f-83b2-d3c51c01dc49",
+      "id" : "5afc7011-c1ad-44bc-8ca1-e80f80ba6fd7",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -384,18 +412,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "79f0e2c3-3ae0-423c-be7a-d1878afda90d",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "id" : "e7c59571-121e-4315-ae4f-070f7b81077d",
+      "id" : "e69a10a5-e096-4840-8eb8-d887bacdf1f2",
       "name" : "role list",
       "protocol" : "saml",
       "protocolMapper" : "saml-role-list-mapper",
@@ -406,22 +423,7 @@
         "attribute.name" : "Role"
       }
     }, {
-      "id" : "0554992e-5796-40a8-ad64-258ef161c7a4",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${givenName}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "8cda7717-8aed-4e6d-8a91-fcb036280fe9",
+      "id" : "5f1287c2-b331-4a67-a5d4-735d51fc774d",
       "name" : "username",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -435,18 +437,33 @@
         "claim.name" : "preferred_username",
         "jsonType.label" : "String"
       }
+    }, {
+      "id" : "ec448f53-fd6e-4ef4-945d-c5becbdb2370",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "5f6dc762-3779-4173-a3f9-eec981f2ddb2",
+    "id" : "8cbf2d17-8141-4575-8df1-31448b20c3a0",
     "clientId" : "broker",
     "name" : "${client_broker}",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "f2b05ad9-b742-4cf7-954e-de6bae67b403",
+    "secret" : "a3dc1db0-7ba9-49f1-8c6c-abc68f959b51",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -458,26 +475,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : false,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "b816ec17-fee7-4564-991d-021dcceacf6e",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "f4fd2469-dcc0-4f71-b471-90a704f0ac20",
+      "id" : "8faacba2-c9ea-4522-ba45-1bb25bfc6937",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -492,7 +495,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "f29944b7-ae82-42cf-801b-ca18be5adcea",
+      "id" : "9d0d04c7-6120-4b3e-add2-b7f004eed28b",
       "name" : "full name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-full-name-mapper",
@@ -503,7 +506,22 @@
         "access.token.claim" : "true"
       }
     }, {
-      "id" : "271e3237-86cd-4ac3-ac19-1bf3ad6fb1f1",
+      "id" : "1ed35b33-1e68-4bce-85cd-01a17846bcfb",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4e3ae324-04f9-402f-9653-c14406df7d25",
       "name" : "role list",
       "protocol" : "saml",
       "protocolMapper" : "saml-role-list-mapper",
@@ -514,7 +532,7 @@
         "attribute.name" : "Role"
       }
     }, {
-      "id" : "727101c6-81fc-4f83-8d39-0609abef66eb",
+      "id" : "fbc7dc55-8241-4170-aa4b-cc1dd30c879f",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -529,7 +547,80 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "e9d5faec-7c8c-4da8-accc-98f7fe947901",
+      "id" : "f3d761ed-0915-4f49-8d75-ba090f5ef897",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "useTemplateConfig" : false,
+    "useTemplateScope" : false,
+    "useTemplateMappers" : false
+  }, {
+    "id" : "1f3be6b3-3d05-4c9a-a62d-30aa573ae787",
+    "clientId" : "openid1",
+    "rootUrl" : "http://openidc/",
+    "adminUrl" : "http://openidc/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "e32e3923-4715-4a1e-a56a-05051c91026c",
+    "redirectUris" : [ "http://openidc/*" ],
+    "webOrigins" : [ "http://openidc" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "b24a1bfb-0a2f-4616-a1ac-402ba5572ef2",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2ab05232-aa65-48c8-852e-6620ea79d612",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "15575195-3040-499d-9ab5-88ad94dd95e7",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -543,18 +634,55 @@
         "claim.name" : "given_name",
         "jsonType.label" : "String"
       }
+    }, {
+      "id" : "3b6d82a2-12d1-405e-a3c1-8fdb469e742b",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "abf86989-04e8-4142-9a67-d0a3b769925a",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "ec1429ed-3699-40df-a9bb-954d1bd2191c",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "f2038460-cf26-454d-aacb-4e640d4e0b41",
+    "id" : "f17735e9-eaed-4a3d-8dd2-03a8bf752153",
     "clientId" : "realm-management",
     "name" : "${client_realm-management}",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "f030f5d4-711f-4370-86e2-34412973967a",
+    "secret" : "b172fb51-f07d-4003-b260-bf2d0ed4dd5f",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -566,11 +694,49 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : false,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "aa52827b-4d66-46eb-a5a4-4331f8600f33",
+      "id" : "b54f1f3c-4d2c-4ed8-a75a-7019ec19133e",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c2c25052-ccb1-4dd4-a5a1-b6d653b53d67",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "85a284f8-0cf7-41ba-bb80-cf2b12d5e2a2",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "ab6565c7-b0c2-4755-9b61-718ab9577370",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -585,22 +751,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "009167c1-59a6-46ac-9f6c-9347e0eaacf6",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${givenName}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "cee9af08-1943-415a-9052-c02b42222521",
+      "id" : "32b24cd8-0968-4b3f-9981-cd041e4ffaf5",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -615,40 +766,18 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "d4d2b426-cfbc-4683-9619-243920c738e8",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "402c65cf-6f92-48d0-a78b-07a8f6d4a413",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "id" : "adf791fd-05e7-43b7-a420-3031de06657a",
-      "name" : "username",
+      "id" : "464befbc-b67f-46ab-964c-f57e47603544",
+      "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
       "consentRequired" : true,
-      "consentText" : "${username}",
+      "consentText" : "${givenName}",
       "config" : {
         "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
+        "user.attribute" : "firstName",
         "id.token.claim" : "true",
         "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
+        "claim.name" : "given_name",
         "jsonType.label" : "String"
       }
     } ],
@@ -656,14 +785,14 @@
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "94e53150-5a8d-405b-91f8-8ae0efbe40b3",
+    "id" : "af062b24-57cf-4286-b98d-4520a4b218e7",
     "clientId" : "security-admin-console",
     "name" : "${client_security-admin-console}",
     "baseUrl" : "/auth/admin/Testrealm/console/index.html",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "5b2e1ef1-0650-4fc7-96cc-c9f07b493520",
+    "secret" : "e294f632-babc-43cc-918b-a250b555aa48",
     "redirectUris" : [ "/auth/admin/Testrealm/console/*" ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -675,48 +804,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : true,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "5254601c-968d-4327-9934-2f32bcfcedbb",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "id" : "44c61cfb-3677-46fd-bf01-130f59989f3c",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "263d3f20-0eab-4cc9-ad7c-a77a545b0e1e",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${email}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "4a8b5034-b1d3-4b0d-91ff-767df5eb90d0",
+      "id" : "205a94c2-f8e5-4c6b-8c92-c259e9c4e346",
       "name" : "username",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -731,22 +824,29 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "158e1b8b-99f0-41c4-a9af-c19173fa9ef5",
-      "name" : "family name",
+      "id" : "1ca9c1ae-110f-4896-a358-b82f7b9eadee",
+      "name" : "full name",
       "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "protocolMapper" : "oidc-full-name-mapper",
       "consentRequired" : true,
-      "consentText" : "${familyName}",
+      "consentText" : "${fullName}",
       "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
         "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "family_name",
-        "jsonType.label" : "String"
+        "access.token.claim" : "true"
       }
     }, {
-      "id" : "07f323fe-b303-4cbd-8810-1b91cb91bd09",
+      "id" : "996a30a9-e3ba-4749-9ac8-f9a884f3afc5",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "fe88c814-8c67-48a5-9d29-67c8b00c60d8",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -761,7 +861,22 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "b5bddb9d-3be4-43d8-91b2-80d5e0e2066a",
+      "id" : "8a487973-a5a8-4aab-bad8-f79a168eaa4a",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "989f39ac-daac-4a05-a4b3-0913a076acdd",
       "name" : "locale",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-attribute-mapper",
@@ -775,112 +890,8 @@
         "claim.name" : "locale",
         "jsonType.label" : "String"
       }
-    } ],
-    "useTemplateConfig" : false,
-    "useTemplateScope" : false,
-    "useTemplateMappers" : false
-  }, {
-    "id" : "23893f51-f313-4560-adcb-6d36dd882f1c",
-    "clientId" : "testclient",
-    "rootUrl" : "http://openidc",
-    "adminUrl" : "http://openidc",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "clientAuthenticatorType" : "client-secret",
-    "secret" : "12816dc7-cf40-4abc-8df7-581e56930cf5",
-    "redirectUris" : [ "http://openidc/*" ],
-    "webOrigins" : [ "http://openidc" ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : false,
-    "frontchannelLogout" : false,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "saml.assertion.signature" : "false",
-      "saml.force.post.binding" : "false",
-      "saml.multivalued.roles" : "false",
-      "saml.encrypt" : "false",
-      "saml_force_name_id_format" : "false",
-      "saml.client.signature" : "false",
-      "saml.authnstatement" : "false",
-      "saml.server.signature" : "false"
-    },
-    "fullScopeAllowed" : true,
-    "nodeReRegistrationTimeout" : -1,
-    "protocolMappers" : [ {
-      "id" : "115e0962-f477-4bae-9583-b69dc2812320",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true"
-      }
     }, {
-      "id" : "a8aeaa4c-2551-46e0-bdf6-de80059cd0f6",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${email}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "36e9c9c7-8264-4163-8a6d-980edf763f8e",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${givenName}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "c8ce6de8-2398-4035-8424-52682ccb3914",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "dade11f6-5e51-40aa-a9ed-ea04cc1cc0fb",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "04bde220-7e24-429d-a338-21602eccb34a",
+      "id" : "935d77da-de1e-47df-9386-4fb73df502c9",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -902,7 +913,9 @@
   "clientTemplates" : [ ],
   "browserSecurityHeaders" : {
     "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
     "xFrameOptions" : "SAMEORIGIN",
+    "xXSSProtection" : "1; mode=block",
     "contentSecurityPolicy" : "frame-src 'self'"
   },
   "smtpServer" : { },
@@ -913,7 +926,17 @@
   "adminEventsDetailsEnabled" : false,
   "components" : {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
-      "id" : "d3b67d7f-7e8d-44e5-b1b1-9c6960149abb",
+      "id" : "0f369094-912a-42d5-9bca-dba1ec7078e9",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper" ],
+        "consent-required-for-all-mappers" : [ "true" ]
+      }
+    }, {
+      "id" : "3a90a5ed-8a33-430a-b463-6a0e5a2205b3",
       "name" : "Trusted Hosts",
       "providerId" : "trusted-hosts",
       "subType" : "anonymous",
@@ -923,21 +946,31 @@
         "client-uris-must-match" : [ "true" ]
       }
     }, {
-      "id" : "123fafa1-747d-4dcd-9a33-f77704f78aaa",
+      "id" : "3e5829c4-8e86-4128-97d8-3a60f2ec386f",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ],
+        "consent-required-for-all-mappers" : [ "true" ]
+      }
+    }, {
+      "id" : "425b2633-e207-43d1-a115-815d809faff7",
       "name" : "Consent Required",
       "providerId" : "consent-required",
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : { }
     }, {
-      "id" : "378c2092-91ea-4f1e-b72f-69f1d0fa56cf",
+      "id" : "705f8b8a-fb55-4a51-80a8-69e5555c3f87",
       "name" : "Full Scope Disabled",
       "providerId" : "scope",
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : { }
     }, {
-      "id" : "f0c86f5e-2e1f-40ff-9e60-4d3cc515a85f",
+      "id" : "8a0614cf-4dd0-4b52-b5ff-e471676f9dfa",
       "name" : "Max Clients Limit",
       "providerId" : "max-clients",
       "subType" : "anonymous",
@@ -946,34 +979,14 @@
         "max-clients" : [ "200" ]
       }
     }, {
-      "id" : "1413edcf-9c78-4332-b975-ffedf87d793f",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "anonymous",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper" ],
-        "consent-required-for-all-mappers" : [ "true" ]
-      }
-    }, {
-      "id" : "d16a6fe1-818f-41a5-913c-63a845ddb63e",
+      "id" : "aac9bc77-dff0-41ad-b7d0-8ed494c3ffb0",
       "name" : "Allowed Client Templates",
       "providerId" : "allowed-client-templates",
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : { }
     }, {
-      "id" : "e8113a25-9d37-488c-9f42-5ddaf3568a4b",
-      "name" : "Allowed Protocol Mapper Types",
-      "providerId" : "allowed-protocol-mappers",
-      "subType" : "authenticated",
-      "subComponents" : { },
-      "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper" ],
-        "consent-required-for-all-mappers" : [ "true" ]
-      }
-    }, {
-      "id" : "86787171-ac5b-4d9d-b39b-7f7b94c232c3",
+      "id" : "c42d675c-148b-47fb-af3e-7f9c9ded9995",
       "name" : "Allowed Client Templates",
       "providerId" : "allowed-client-templates",
       "subType" : "authenticated",
@@ -981,14 +994,23 @@
       "config" : { }
     } ],
     "org.keycloak.keys.KeyProvider" : [ {
-      "id" : "0841dfe5-b727-4700-88e9-f2e9c356c6ae",
+      "id" : "604f78b1-dd60-4524-b71e-a6fb3d2e4452",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "dd0cee1d-0b36-4768-9e17-dcb6fe0b2998" ],
+        "secret" : [ "fVEiGry9-PTC39Cr-gRMjJfkeq9YOpQBhpkVlAER6WQ" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "762d2098-eebd-4f57-90e5-bcf40cb8ce7d",
       "name" : "rsa-generated",
       "providerId" : "rsa-generated",
       "subComponents" : { },
       "config" : {
-        "privateKey" : [ "MIIEpAIBAAKCAQEAhXiHgirj0netESCkyEgA4uirUe3qrHiiWddpYSOtSlIbD1JZPgJ1dNouG71dSmHVJ8hcBwRSwl+YQifkQvSlLIxzW2wz7VfXSXeXA7LZWf3pPML96t1T/WoXUoQ4+gSjbpCGx2/XdqvTwCeMq37D/i9oT4sFlV29v6hXw2WCHN4+ZqFFKy5rAJ2U3/YhwXhvIejO+yd5YifFBsLiKTGnRL0mf7X+Uo2B32RDSqRRUFfRpTRz36Be11BzGH6NZO4eAV45JfOoprLQCSpmMuFXAwOXVXG/qj4zVPxh73j+kSvQ9J7aRrV+9x+/wdKiN41Ib0prJkazg1dwCLJXk63sSwIDAQABAoIBAAs+cSP9Gv4zCMhlmJwqvLBg63XWdiubagnphL4jNEkLi64JwOzhZiW276V0mXRXs45Lab1JlvM6/GeuVqNxWqzbFCjCf8lh2ggdZAJywa68Hjb5Mkzj4lx54IcaDna5h08cK86HVH5x0T/h1Q7pefdi5QW2b3z6za5krygN2B04WJIrOJniDNt0zjIVjodWlzj0zJuscNB34krp8JyEso/QPMdzda1HjAU1IvLzPeJUbIJoc/ZnfSznkrkS5pZOGGc1B8zX8o75i10jKUtzU7I64Apmxsz0+RmGaSGxGxmR8427nXde86Q3ACtkFC3jU4NIRtbeX0Tki9TsXOw4TUkCgYEAxQl/RDQ64bcnMv2YHTmaHR4aBIxKiB+lo/dlgJVhmi3bsh0A/DpaEgQhX1ljkSyjWNQM2XSBPXaCKAuSna8uVH5x0CkKbfNt3bE+WLnf+MNcwfSUQKBbk8sd/Ls8BmNjxDuVnDhW2uWyUowyh1iQgJ0ascbREvjqwjDtiQIotS0CgYEArWliPBRddCp1JYSHcVDetjEP9WUH22DNBnQ0jXePXQ0bM8MwS71a1hBYiYUc6lrGv6EeZ7KxiPJqD9q42qYvIZjtqWZFk5eVJfdb06tVJinVAP+L4ONo8yoAZjgrIJSrqp8zeYwl1smSsGEPpBOjdNb43VkY4kdiZedW68DmAlcCgYEAtzmopjTnmGPnyMv3ex3IiVEnopkO6dx7/KifM941n9kLFmtQMjzU6zH6Ep+eLi7TS1QNCt4DHLOqPzDby1RPAfV/QrIXZ71ZqjEbKAjZFIwfIqGchyhXYG0eWpmGLO6ZpK4/5sChS/cTRx3mEuQxo9f0LeMTItBkBebXzHM8hZUCgYAtkHcjWiaEE3Pce8oq2Bjsvk93Jyi9V94HSBlW4odk58CyBSN3gzWO8ZSR7cv/OALo7yjSDn3fgfKkX9Aag3f21/v6esjlUvr5ktkp8ObatDsnm/3hBV/aJLseILwUP3wrxND9qvl2Slikx5wYfKCCXsndPz/ulNsh83s/Ttwg2QKBgQC+/zAAtKU9BXbjitOg4d9b9fFm98TZHVHQ+U62td5C6ljSsyyft3tOQLXdfnd4+umtXgXqz5cArP2jUQUMeeSPkm7GLH4tu0HSPmt9rxBBxP4l8lgurh05Y2Al0gTABufh3UqTJAbjTiXFLpJAqB/KAkhhAl7iwcZNZHUrpf592A==" ],
-        "keySize" : [ "2048" ],
-        "certificate" : [ "MIICoTCCAYkCBgFYAQKA8jANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAlUZXN0cmVhbG0wHhcNMTYxMDI2MTIzOTUxWhcNMjYxMDI2MTI0MTMxWjAUMRIwEAYDVQQDDAlUZXN0cmVhbG0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCFeIeCKuPSd60RIKTISADi6KtR7eqseKJZ12lhI61KUhsPUlk+AnV02i4bvV1KYdUnyFwHBFLCX5hCJ+RC9KUsjHNbbDPtV9dJd5cDstlZ/ek8wv3q3VP9ahdShDj6BKNukIbHb9d2q9PAJ4yrfsP+L2hPiwWVXb2/qFfDZYIc3j5moUUrLmsAnZTf9iHBeG8h6M77J3liJ8UGwuIpMadEvSZ/tf5SjYHfZENKpFFQV9GlNHPfoF7XUHMYfo1k7h4BXjkl86imstAJKmYy4VcDA5dVcb+qPjNU/GHveP6RK9D0ntpGtX73H7/B0qI3jUhvSmsmRrODV3AIsleTrexLAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACsbSbwWwTVprqRY2viI2dixzLQ8EJ4PutkRFr2oUqq67nk/t/QoDIb/K7DfJdYg8RIxRibKUJdHeTgHX1VN6/b/tKyNP2udybsAV3nro9Ht0CudyUMvIeONc0FNW+K1y/FVSU1Zo5HtidgaZZOSoKQoaE4AJDVQfPUbr/RZlxh1YeEB7B0cEUJx553jM0B501kRvmXB5YwlT1oN1YrXAjdqivQ3pNpYZMPc+++SQTRQ1X5SJQupbx6Kww/91KvXoA/Wg8Qhr9/iLD/Xyn1ZGIDm/0cxr7p8XRGl4G2nlTXi4Cv0Ka2fZLOomUy6h1LOhidjSI1RJkVCrsiaaF+3TsE=" ],
+        "privateKey" : [ "MIIEpQIBAAKCAQEAj0rfARlWsrxj6qleEe1/a1yE9ZGBcsEm6cCFHezcDgmK0rCkOsTjM/KBxzSJf6xOp7qMmUEKxSsx73Z+yf1aM0v8lGv09fH9ilyyk/vWv5kOfZOkLNAvYqCd8Ls9dkj/m4lo30LD2zwMSx5nfY5j6hlKGOq1u+sIehBhqbx2kRIHnMOMzHKDrqvPaR441HzgbfQWc/q9VtI5Y3YjZgwixj1596qDB5rjZ8aTVAitC1qmsqpgo+smJOmbF6zneVgSw2jy7mA1Dd7G9VYlHPRyqh5bVTeC+0gdxiOKiWuUE19RbTqmw8Rjyuxg2aEZTSSjW4Z3SeTkjg+urQVmsIFALwIDAQABAoIBAH1V0/G2JCt6tTrQokO0JTvXVUUm3L9vS4Yyqz0drO1qU08uyrfM9568g9+miI5wPOxhNBHo3m7P9YGreANd48Pytx9rvnxSCp83rcvbAF/elNoqhfPctVXjf8LNRFluSIXXjy+Zyo6821PpaEReg+6D6FgbFJMmZee+5G3/NwZ0GXgbXTDf2dnSAJphtXMxmHPL8KNvLmmd9BPUUxP5Pxw5hvcb25nAHC2b/3oKsOPXKQNvHHOW/zH7OkKLNBicgQDGpJGMG/mrhZQ66/tORfl5QCY/VlAsA1sfHshOD2tA5sm0upCfG+sFz63ObeXIj/JNkul1DWKC8B2x7YQNBQECgYEA1yyA2T7oAtSdYy2oTCE2XbyOeZ+1qz8Hym5zh6iD2LX/XSVDk2lvU2DLOd6ZlsOEe5srMlfmfdDQliyrxN9bvAaWkpb1fXjG27RdK5JEE/pVJfLO9NRtvTNSY8WFRAKtI3asWT1uF1sMGFKq5oCoZSkhJbntNaY1jir+SJvjw08CgYEAqnrr2Adh59OgTVhDkYoayFYGJhgZDA0yNklXZI8fNANzGVXvdCOXzlhLjRe2hwXd72F8gHlpV0cr9AwLjjqp/9OZYtv+7DfCcjHgMoQWWJ0/S8mNx7EffiQpA0qIOkQa+Y7lmZS6PeL/cV1UpLZpvyPG2OG6c+endGjLq/Xg/SECgYEAts0TJf1AZG82yrRWP18T7eyr6f3Z/AMPXlYZhk2OvYRYz0xCLbEsJ9yaqq5HM4MlQVGhECMHKSpGmt6WiynqqEG8mArxwkfiQXLomISpm4NX5WZzliIGnO9F9ocu4YmYiAFhCGuc5PCvxNYuZKc26MJZa9CaCrMK2p4B67OsexcCgYEAn+nr/tl18kMl9EdeIlA8rT1cSTGDlTVvq1KCorZKG708o0Bj/DpC9PEH9ZKPyfor45c7dTvuH0uIpEUENec7fdjb4crhRm1LfVjhqCEU4QynygyHbRDtrKJ4wjiQrq8h6oQrRTQou1KKMKnOcy8U5JHHvbuH7Z8YCe8fVe+vm2ECgYEAmDmpWbEkB5YMl0MFOxpwY35YBU+PnHGKm6rhvzTzj5SXWTWLPfB1zcXbstds+0VKuPextSfny3fBXDl6BbCXWReG8nwpnlCdgib2P98pmkN0/mA8jLc7EQ0GLm5u2w5hOte0HoZSYYxFVYWSCFnsFxqszOjdn39xIl6yvVJAgTY=" ],
+        "certificate" : [ "MIICoTCCAYkCBgFcP/knlzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAlUZXN0cmVhbG0wHhcNMTcwNTI1MTQxNjUyWhcNMjcwNTI1MTQxODMyWjAUMRIwEAYDVQQDDAlUZXN0cmVhbG0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCPSt8BGVayvGPqqV4R7X9rXIT1kYFywSbpwIUd7NwOCYrSsKQ6xOMz8oHHNIl/rE6nuoyZQQrFKzHvdn7J/VozS/yUa/T18f2KXLKT+9a/mQ59k6Qs0C9ioJ3wuz12SP+biWjfQsPbPAxLHmd9jmPqGUoY6rW76wh6EGGpvHaREgecw4zMcoOuq89pHjjUfOBt9BZz+r1W0jljdiNmDCLGPXn3qoMHmuNnxpNUCK0LWqayqmCj6yYk6ZsXrOd5WBLDaPLuYDUN3sb1ViUc9HKqHltVN4L7SB3GI4qJa5QTX1FtOqbDxGPK7GDZoRlNJKNbhndJ5OSOD66tBWawgUAvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHFNguHCw7EYcMLMjkLtupwFLglThVk0Sl8VJwbfOLvJp2w2dxraU7gUiK7CKbk9UUrGaB+oS+1Iqw0RmYoQnVj2bOotsxKLc4MGuhA6ZhmIQnPeJciFtVRyGBW2kCOk0ThWDjQGDQFmokAF9ve2fEgdq1RWs0dUAE69aKlzRx2B0D4XelRHhaJC9a0FW/RBRdMbxUIomBz4qGvyrdbo/ROQy+c8NRNMmopDUOGSv9kVFrpKBd0aijv8vBkhC49UgUsgumAzXzXwuZasdJhGtwLaCTl0zCsP27Bg14nZOvBrc5RKNQD83/2HL7UX5YK2Wt383eBqu9PnNuhBayVcgAE=" ],
         "priority" : [ "100" ]
       }
     } ]
@@ -996,7 +1018,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "25e87b65-d0a7-47c8-8608-96d2e28a95b1",
+    "id" : "af9ef1d8-506c-4986-95dd-42bb355232e6",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1022,7 +1044,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "ee30afb3-dc62-4d12-9097-e6a0a94e6265",
+    "id" : "c032f83f-85a0-453c-b6b4-b5cfd6401a91",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1042,7 +1064,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "907f4d2b-e9e4-4f69-90ec-0afbe18e3b44",
+    "id" : "8794fb7d-c98b-4b05-a174-8e7d69dda071",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1074,7 +1096,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "2261fe5e-124d-43e8-a93c-c5ffa8a26e29",
+    "id" : "dd4525c3-7f02-45ce-bf4a-0b2b4b80b84f",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1094,7 +1116,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "0f562c18-8510-4739-9a41-323f1b8b7793",
+    "id" : "b9285674-f37e-43c7-9390-88d66eb205f0",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1120,7 +1142,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "32a9e465-02ad-4214-a5a8-d4b273281c78",
+    "id" : "a336b5b8-4be1-4d9a-a64f-805db6542a65",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1148,7 +1170,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "09fa4a06-0355-45f4-b310-cf5410c5a54f",
+    "id" : "a14025db-4c0c-45c8-99c0-d550f4e1485d",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1168,7 +1190,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "2a276a8e-3f30-4eac-bcec-148215a03186",
+    "id" : "33dae808-e5c4-43c4-8ef0-008f8d7e9cfa",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1183,7 +1205,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "0bf116f9-cdbe-4648-af23-a6b5cea4cb13",
+    "id" : "1bd89f4d-86fc-4d65-b01d-bfcd919dfda7",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1215,7 +1237,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "b1a60041-05ca-4b73-be93-4a61fd51dec0",
+    "id" : "d4e81d04-db78-4350-b00d-e6a3abcd6b48",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1247,7 +1269,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "7c85c9b6-e083-4857-ac67-4be91392ffe3",
+    "id" : "fad2bb73-517a-49fb-ae12-fc58a3a472e7",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1262,13 +1284,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "daf5c872-d6fb-4889-8e1b-cbb0c0a24b40",
+    "id" : "cc212d74-75d5-4c00-a2f8-129f4648019a",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "02e80c67-b0ba-40a5-ad6b-722ac44e232e",
+    "id" : "c72c87d1-d9ac-4ca6-9382-c7fbb741534f",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"
@@ -1316,16 +1338,18 @@
   "resetCredentialsFlow" : "reset credentials",
   "clientAuthenticationFlow" : "clients",
   "attributes" : {
+    "_browser_header.xXSSProtection" : "1; mode=block",
     "_browser_header.xFrameOptions" : "SAMEORIGIN",
     "failureFactor" : "30",
     "quickLoginCheckMilliSeconds" : "1000",
     "maxDeltaTimeSeconds" : "43200",
     "_browser_header.xContentTypeOptions" : "nosniff",
+    "_browser_header.xRobotsTag" : "none",
     "bruteForceProtected" : "false",
     "maxFailureWaitSeconds" : "900",
     "_browser_header.contentSecurityPolicy" : "frame-src 'self'",
     "minimumQuickLoginWaitSeconds" : "60",
     "waitIncrementSeconds" : "60"
   },
-  "keycloakVersion" : "2.3.0.Final"
+  "keycloakVersion" : "3.1.0.Final"
 }

--- a/build-contracts/keycloak-setup/export/Testrealm-users-0.json
+++ b/build-contracts/keycloak-setup/export/Testrealm-users-0.json
@@ -1,29 +1,30 @@
 {
   "realm" : "Testrealm",
   "users" : [ {
-    "id" : "c11e38b3-ac64-41c7-9d0f-40ca55defc8d",
-    "createdTimestamp" : 1477485701643,
+    "id" : "ad1e0f60-dd68-48a3-80e5-f8106329c3f3",
+    "createdTimestamp" : 1495722085372,
     "username" : "test1",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
     "firstName" : "Test",
-    "lastName" : "Openid",
+    "lastName" : "Openidc",
     "email" : "test1@example.net",
     "credentials" : [ {
       "type" : "password",
-      "hashedSaltedValue" : "72SjVDs19PPoDcNX8qoj76L7G88rEAWZLAHIxBBIx8YtyhGh/UTAhMeycYKj6Mo/tSdwLCVXJyc2gmmUX3IV2w==",
-      "salt" : "tyjH4pAUQO/fY176uWiqIA==",
+      "hashedSaltedValue" : "9ECfgutZvTKru6guZtaxNON3JNBUCk9hsp/0vrckoYFWmkFAVkoAgO21bP2bsCMYMAGvS8zRQi5HJdVcW2x/dg==",
+      "salt" : "lBxnQwZKzUhMlL20iSgjwQ==",
       "hashIterations" : 20000,
       "counter" : 0,
       "algorithm" : "pbkdf2",
       "digits" : 0,
       "period" : 0,
-      "createdDate" : 1477485718898,
+      "createdDate" : 1495722095099,
       "config" : { }
     } ],
+    "disableableCredentialTypes" : [ "password" ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "uma_authorization", "offline_access" ],
+    "realmRoles" : [ "offline_access", "uma_authorization" ],
     "clientRoles" : {
       "account" : [ "manage-account", "view-profile" ]
     },

--- a/build-contracts/keycloak-setup/export/master-realm.json
+++ b/build-contracts/keycloak-setup/export/master-realm.json
@@ -19,6 +19,8 @@
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,
   "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
   "resetPasswordAllowed" : false,
   "editUsernameAllowed" : false,
   "bruteForceProtected" : false,
@@ -30,7 +32,7 @@
   "failureFactor" : 30,
   "roles" : {
     "realm" : [ {
-      "id" : "26b9f6ee-a860-46a3-b2df-ef1a7346a8fd",
+      "id" : "004133d7-47d6-495b-94ee-dec485a2bfd9",
       "name" : "uma_authorization",
       "description" : "${role_uma_authorization}",
       "scopeParamRequired" : false,
@@ -38,22 +40,7 @@
       "clientRole" : false,
       "containerId" : "master"
     }, {
-      "id" : "dd84bca6-2aa3-4768-be70-9b9e7a4acf0a",
-      "name" : "admin",
-      "description" : "${role_admin}",
-      "scopeParamRequired" : false,
-      "composite" : true,
-      "composites" : {
-        "realm" : [ "create-realm" ],
-        "client" : {
-          "Testrealm-realm" : [ "view-events", "view-users", "manage-users", "manage-authorization", "view-identity-providers", "manage-clients", "view-authorization", "view-realm", "impersonation", "manage-identity-providers", "view-clients", "manage-events", "create-client", "manage-realm" ],
-          "master-realm" : [ "create-client", "manage-identity-providers", "view-realm", "manage-clients", "manage-users", "view-clients", "view-events", "view-identity-providers", "view-authorization", "impersonation", "manage-realm", "manage-authorization", "view-users", "manage-events" ]
-        }
-      },
-      "clientRole" : false,
-      "containerId" : "master"
-    }, {
-      "id" : "0e8d8835-4a97-4659-8027-e7b0c868dcbd",
+      "id" : "29875929-68a3-4ad4-becd-cfe077695986",
       "name" : "create-realm",
       "description" : "${role_create-realm}",
       "scopeParamRequired" : false,
@@ -61,273 +48,301 @@
       "clientRole" : false,
       "containerId" : "master"
     }, {
-      "id" : "a68e4c78-af37-4a2d-a9bd-2e36b8dac192",
+      "id" : "243ea332-177d-4626-8585-06583e8d354d",
       "name" : "offline_access",
       "description" : "${role_offline-access}",
       "scopeParamRequired" : true,
       "composite" : false,
       "clientRole" : false,
       "containerId" : "master"
+    }, {
+      "id" : "790f22ac-fb65-4fa9-8df4-29d6731f4bbe",
+      "name" : "admin",
+      "description" : "${role_admin}",
+      "scopeParamRequired" : false,
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "create-realm" ],
+        "client" : {
+          "Testrealm-realm" : [ "view-authorization", "manage-identity-providers", "view-events", "impersonation", "create-client", "manage-clients", "view-realm", "view-identity-providers", "manage-realm", "view-clients", "manage-users", "view-users", "manage-events", "manage-authorization" ],
+          "master-realm" : [ "view-clients", "view-events", "manage-users", "impersonation", "manage-clients", "manage-events", "view-identity-providers", "view-realm", "manage-realm", "view-users", "view-authorization", "create-client", "manage-identity-providers", "manage-authorization" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "master"
     } ],
     "client" : {
       "Testrealm-realm" : [ {
-        "id" : "153d0db5-c126-4a48-bcfc-7db0d9eef70d",
-        "name" : "impersonation",
-        "description" : "${role_impersonation}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "2c5adec5-63c9-499b-8781-96f610e6400e",
-        "name" : "view-events",
-        "description" : "${role_view-events}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "7cf10cdf-bf8e-4229-874b-c14717a02169",
-        "name" : "manage-identity-providers",
-        "description" : "${role_manage-identity-providers}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "c6deecf0-685b-4b4d-9bf4-b59339900607",
-        "name" : "view-clients",
-        "description" : "${role_view-clients}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "65c4bc83-037d-4da4-ac7a-0a7bb10496e6",
-        "name" : "view-users",
-        "description" : "${role_view-users}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "e0e6d1d5-cf0d-4cf6-8c55-35340acf4c9f",
-        "name" : "manage-events",
-        "description" : "${role_manage-events}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "a0f622f5-4c3d-4646-8e2a-ca498e66cf79",
-        "name" : "manage-users",
-        "description" : "${role_manage-users}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "8a31c7c8-ad70-4003-b707-bf556da7a483",
-        "name" : "manage-authorization",
-        "description" : "${role_manage-authorization}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "92d01210-20c4-4f62-b213-019100e67eb3",
-        "name" : "create-client",
-        "description" : "${role_create-client}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "f33f63ce-c5c2-4d10-b70a-eeaeaff67450",
+        "id" : "05c17a17-41b3-4876-ad4c-48e2aa13dc22",
         "name" : "view-identity-providers",
         "description" : "${role_view-identity-providers}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
       }, {
-        "id" : "25b2ea90-ec7b-4a47-aed8-56b8ea470f04",
-        "name" : "manage-clients",
-        "description" : "${role_manage-clients}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "4a611705-6fd7-49e0-adff-86a90193646d",
-        "name" : "manage-realm",
-        "description" : "${role_manage-realm}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "5a4b637f-88a2-47ae-93ac-d31638679fd5",
-        "name" : "view-authorization",
-        "description" : "${role_view-authorization}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
-      }, {
-        "id" : "4081662c-2fd1-41fe-ac60-08cfc5302b6a",
+        "id" : "9a8f8e74-ddbf-405e-80d1-e8150ec1fcea",
         "name" : "view-realm",
         "description" : "${role_view-realm}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93"
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "130cfe5d-220d-4a72-89ed-46c51b1eaea0",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "cefff127-3fd0-4a35-829b-7d76e3293a84",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "b716fbd6-ac85-4f9c-9327-d511a5462c6a",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "cbab7136-612f-4aae-90eb-aeea05f24d63",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "fd1ffd70-a28f-4ecf-96ec-e7960bcbea2d",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "63bdd909-cb67-4a07-9948-53848db23afe",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "e1d1f592-430d-4f0e-ab17-180b7e40d6fe",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "faef05e0-069c-45eb-bd24-3c3c88d77d8f",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "3f5edb27-a3ba-4fcd-8149-c293c2a6e0d0",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "e0ad0690-0fed-4d01-8348-6bcf6a59c143",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "f51fece8-d847-4d04-9fab-02aac98fb622",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
+      }, {
+        "id" : "abd0b025-22bb-4841-96f2-6343ffee0ce9",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68"
       } ],
       "security-admin-console" : [ ],
       "admin-cli" : [ ],
       "broker" : [ {
-        "id" : "cda9b7c8-2f3f-4ab2-ae1b-e41b31f26428",
+        "id" : "7d6fb833-6049-48db-a87a-75fba9e89f88",
         "name" : "read-token",
         "description" : "${role_read-token}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "1dbc8956-4398-4ae1-9b31-57c75406a4ce"
+        "containerId" : "d0b9937a-48fe-491c-9617-364836deedb0"
       } ],
       "master-realm" : [ {
-        "id" : "647c0160-b4d6-402e-9dbe-93c6bb8eade6",
-        "name" : "view-events",
-        "description" : "${role_view-events}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "37c3b56a-29b3-4e9a-a979-613ff8089233",
-        "name" : "create-client",
-        "description" : "${role_create-client}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "99117dbe-a0c9-41d0-8d98-60344b531797",
-        "name" : "view-identity-providers",
-        "description" : "${role_view-identity-providers}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "b52290cd-1c1d-434a-a0ed-666ed2f6dda9",
-        "name" : "manage-identity-providers",
-        "description" : "${role_manage-identity-providers}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "27132982-b7fe-4210-a16e-c6413f19a2ac",
-        "name" : "view-authorization",
-        "description" : "${role_view-authorization}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "0680e239-7f3b-43ef-ab45-e2b04637ce23",
-        "name" : "impersonation",
-        "description" : "${role_impersonation}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "3e45512b-645e-4bb3-9e8e-8df98262d01b",
-        "name" : "view-realm",
-        "description" : "${role_view-realm}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "721c827e-e192-4191-99b7-efabbcb93f8e",
-        "name" : "manage-realm",
-        "description" : "${role_manage-realm}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "e4cea240-aa4a-4df5-ad72-aae8a3e29a55",
-        "name" : "manage-authorization",
-        "description" : "${role_manage-authorization}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "aca88cf2-910b-4946-bffc-6479a788b18d",
-        "name" : "view-users",
-        "description" : "${role_view-users}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "6a8761f7-7004-4645-9ed6-f832a5a85917",
-        "name" : "manage-clients",
-        "description" : "${role_manage-clients}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "2855d07a-629b-495c-ba3c-006ae5ba58b4",
-        "name" : "manage-users",
-        "description" : "${role_manage-users}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "bac97b75-fbe0-4cb2-aaa7-d9c29ae36552",
-        "name" : "manage-events",
-        "description" : "${role_manage-events}",
-        "scopeParamRequired" : false,
-        "composite" : false,
-        "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      }, {
-        "id" : "0f6768dd-df3e-40a4-98eb-2950e659890b",
+        "id" : "51d17439-dfec-45ec-987d-072442412d2f",
         "name" : "view-clients",
         "description" : "${role_view-clients}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2"
-      } ],
-      "account" : [ {
-        "id" : "618eb699-84a2-4f4a-8333-c07361636108",
-        "name" : "manage-account",
-        "description" : "${role_manage-account}",
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "230cae07-685b-4144-b4dd-01f2abf66c48",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "0567d0d7-c6c1-41c6-bd7c-4b5e66998784"
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
       }, {
-        "id" : "c0e682dc-6c98-4108-9ee3-bfa58e03d1d8",
+        "id" : "fef2857b-5a3a-4fb0-962d-276671cb36f6",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "8f017a05-6b1a-4244-9e41-0bcc4befbdae",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "cd1f8be1-e2c5-4e12-b81f-a85c1fa1a124",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "8963f2bc-2958-4fbe-a5d3-b3078bf0d060",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "c73bb78e-c5b4-4694-9950-c76ece7ecf7d",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "52847d10-2b1c-4570-a91b-ca1380870f6a",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "a802cac9-b105-4677-b6dc-b3430b11f903",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "418baa3c-1ddc-4a18-8719-068bd576c0cf",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "5e300c5a-db1d-45a5-8870-a373f4b761e2",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "f6ce9e94-ed92-4975-a77b-c1ca927b6c96",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "bb3323ae-d383-4cec-bbb8-b6832bc2935b",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      }, {
+        "id" : "d0338c5b-b437-43b2-bd77-a8f9f324f1ca",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b8612586-89eb-4208-bc0f-3da44d01d8b6"
+      } ],
+      "account" : [ {
+        "id" : "4a7789d0-d746-4b62-83db-24e090bd5be1",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9e9f3b3f-2e10-4fd2-aacd-6f83ba2911b4"
+      }, {
+        "id" : "6fd0ba1a-4991-4a2d-b31a-a848d2c71495",
         "name" : "view-profile",
         "description" : "${role_view-profile}",
         "scopeParamRequired" : false,
         "composite" : false,
         "clientRole" : true,
-        "containerId" : "0567d0d7-c6c1-41c6-bd7c-4b5e66998784"
+        "containerId" : "9e9f3b3f-2e10-4fd2-aacd-6f83ba2911b4"
+      }, {
+        "id" : "001c4edd-65bd-429d-a355-30df9aadbc29",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "scopeParamRequired" : false,
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "9e9f3b3f-2e10-4fd2-aacd-6f83ba2911b4"
       } ]
     }
   },
   "groups" : [ ],
-  "defaultRoles" : [ "offline_access", "uma_authorization" ],
+  "defaultRoles" : [ "uma_authorization", "offline_access" ],
   "requiredCredentials" : [ "password" ],
   "passwordPolicy" : "hashIterations(20000)",
   "otpPolicyType" : "totp",
@@ -344,15 +359,15 @@
     "roles" : [ "admin" ]
   } ],
   "clients" : [ {
-    "id" : "0567d0d7-c6c1-41c6-bd7c-4b5e66998784",
+    "id" : "9e9f3b3f-2e10-4fd2-aacd-6f83ba2911b4",
     "clientId" : "account",
     "name" : "${client_account}",
     "baseUrl" : "/auth/realms/master/account",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "a58073e9-22e7-4c88-9919-ee2008b7774f",
-    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "secret" : "87c97188-9256-4c9b-a003-f49a3a4a9ec6",
+    "defaultRoles" : [ "manage-account", "view-profile" ],
     "redirectUris" : [ "/auth/realms/master/account/*" ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -364,11 +379,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : false,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "e65b62ad-6a92-4c50-87be-0bb1b3417ca2",
+      "id" : "00d1c3c6-510b-4b23-918d-37d975302020",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -383,7 +399,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "32600572-bffe-4c6f-a157-e9f1c2dbe353",
+      "id" : "58b4cf94-0662-4174-b737-65e3d9010f49",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -398,33 +414,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "1876b112-857c-488f-a3e4-1b6289c6b1e9",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "8218a42f-e0a9-4f50-8909-47ea02888f10",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "82c0dd3b-e511-4f51-8bf6-9f62e389dea1",
+      "id" : "29b3579f-829b-42bf-9233-dbe3c438b3f4",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -439,7 +429,33 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "6b3a0866-48b8-4ab3-b5fe-2c5c6251b39a",
+      "id" : "7aefaa72-7d12-4883-b91c-137aaaa8f9be",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "faab722a-cdf0-4e50-b05e-ace731927f3b",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "f58f1258-7ec4-4907-a048-20fc15e324eb",
       "name" : "full name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-full-name-mapper",
@@ -447,21 +463,20 @@
       "consentText" : "${fullName}",
       "config" : {
         "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
+        "access.token.claim" : "true"
       }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "2567dadf-bf4e-477c-9740-a6cc52982c48",
+    "id" : "7ac8a6fe-3631-4750-892b-5c7d7b312670",
     "clientId" : "admin-cli",
     "name" : "${client_admin-cli}",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "68820b48-6c09-4de8-a4e4-edc5fd48aab3",
+    "secret" : "092ea0eb-e67b-40a9-b201-3acc8d7d5f03",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -473,67 +488,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : true,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "edb1b86c-9d71-43d2-8644-d9c6bd407aee",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "2084414d-f1fc-411b-b90d-424c999d89bc",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "b1f7d400-e819-4543-a7cb-1e379f6837cd",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${email}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "a8588484-7175-4092-b8ea-354977df67b6",
-      "name" : "given name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${givenName}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "given_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "c92d55fe-1e45-4228-9b3f-29aedf542a8e",
+      "id" : "bd1cf36c-bb9c-4cc0-9aad-11528bc68aaf",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -548,7 +508,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "ea84d0a1-c46e-4fba-ba5d-2b920ffe1e3d",
+      "id" : "5011e27c-a197-4c67-8d0e-16ce20edd923",
       "name" : "full name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-full-name-mapper",
@@ -556,21 +516,76 @@
       "consentText" : "${fullName}",
       "config" : {
         "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "8daad1d0-c753-4d13-acf3-0ee99c513b5e",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
         "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "683f001f-5d03-4f2b-bfaa-ad361fbae3e6",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "6ae23af9-51b2-4a30-8f11-fc90dc68eb85",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "71f3da52-93e8-4c0e-909b-379966ebe506",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
       }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "1dbc8956-4398-4ae1-9b31-57c75406a4ce",
+    "id" : "d0b9937a-48fe-491c-9617-364836deedb0",
     "clientId" : "broker",
     "name" : "${client_broker}",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "1e877236-5d16-411e-999e-c65b30c3e66b",
+    "secret" : "26d673ba-d21e-4c79-b346-146f3be53c0b",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -582,11 +597,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : false,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "5dfcb028-c26f-4b1b-95ba-23bce3361768",
+      "id" : "7577d832-57c4-40f1-a8dd-154aa7cc7968",
       "name" : "username",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -601,7 +617,33 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "41eba277-aeee-4a06-9731-9ffd75290c36",
+      "id" : "94176fe5-4770-4395-bb83-494e4c8b6290",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3e6124db-ebbd-431c-b22b-30830d31ab43",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "d7e1b8bd-db07-49bb-8b13-65603b596659",
       "name" : "role list",
       "protocol" : "saml",
       "protocolMapper" : "saml-role-list-mapper",
@@ -612,7 +654,7 @@
         "attribute.name" : "Role"
       }
     }, {
-      "id" : "cf430ee6-cbfb-4287-8def-a520007859f6",
+      "id" : "1c3fdc07-7ddb-468a-a3b5-96dd9fff87b4",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -627,19 +669,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "cbfb251e-79c1-468d-9b5a-33119feb14ae",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    }, {
-      "id" : "73ddd639-f415-4d29-a083-5bfab0b45a89",
+      "id" : "1df96cea-50b7-4b5e-bdd5-f179fce05eb4",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -653,33 +683,18 @@
         "claim.name" : "family_name",
         "jsonType.label" : "String"
       }
-    }, {
-      "id" : "fb8705ac-1817-4126-b822-a27120f413da",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${email}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "6a457c6e-f0b1-4878-9c5b-ac86b76927a2",
+    "id" : "b8612586-89eb-4208-bc0f-3da44d01d8b6",
     "clientId" : "master-realm",
     "name" : "master Realm",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "ca2a316e-c710-4fdf-b1c3-60fdf0f9d77f",
+    "secret" : "e88f813e-8e3b-4a75-ba98-3b5ce5cd5f47",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -695,60 +710,22 @@
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "a656c65d-91ed-48fb-a89f-6c96dea7c827",
-      "name" : "family name",
+      "id" : "83b1ce89-443f-4feb-a925-b7df4677e981",
+      "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
       "consentRequired" : true,
-      "consentText" : "${familyName}",
+      "consentText" : "${givenName}",
       "config" : {
         "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
+        "user.attribute" : "firstName",
         "id.token.claim" : "true",
         "access.token.claim" : "true",
-        "claim.name" : "family_name",
+        "claim.name" : "given_name",
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "9325d96f-e6d1-445b-99f4-05f9e77ff72a",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "43e6a44f-3f33-44b0-b8f0-3f3f19ba057b",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    }, {
-      "id" : "205a1703-1716-4f6b-96d9-dee0dab94c0a",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "6fab3a7d-3902-4491-8e26-7105c423f13f",
+      "id" : "c43bdbce-e7a0-47fe-b71c-8fca83f60466",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -763,18 +740,55 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "81d42682-d756-419a-a3e9-ba8e6d1b6e25",
-      "name" : "given name",
+      "id" : "4660d5aa-d424-43cf-89c7-fbf9d615bd45",
+      "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
       "consentRequired" : true,
-      "consentText" : "${givenName}",
+      "consentText" : "${familyName}",
       "config" : {
         "userinfo.token.claim" : "true",
-        "user.attribute" : "firstName",
+        "user.attribute" : "lastName",
         "id.token.claim" : "true",
         "access.token.claim" : "true",
-        "claim.name" : "given_name",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f3db5f19-d86a-47f2-99e5-107905f9b279",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "8c6f4b7f-70d0-4d7e-91d9-fa4178d6182c",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "028fbef7-4616-4604-8ef1-6767607af455",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
         "jsonType.label" : "String"
       }
     } ],
@@ -782,14 +796,14 @@
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "c14ed48d-caae-4596-8c3b-08347797c6a9",
+    "id" : "686cfbec-0e65-4e9e-9e8a-0950061e11b0",
     "clientId" : "security-admin-console",
     "name" : "${client_security-admin-console}",
     "baseUrl" : "/auth/admin/master/console/index.html",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "d33757d2-b7cd-4bda-8796-3fd6c6ed9339",
+    "secret" : "c52e22d3-31fc-4edf-b4d1-e9e2c0c544cc",
     "redirectUris" : [ "/auth/admin/master/console/*" ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -801,38 +815,12 @@
     "serviceAccountsEnabled" : false,
     "publicClient" : true,
     "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
     "attributes" : { },
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "5103ad2e-2d65-421e-844b-b65111b15b53",
-      "name" : "email",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${email}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "email",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "email",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "8a957532-e9ea-405f-98fc-4f03e2c9c6a1",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    }, {
-      "id" : "426e992e-5f14-4d10-811e-0124136bd374",
+      "id" : "12c48023-c02d-412c-b3da-da2c5b34bddf",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -847,48 +835,7 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "fab40c2f-538b-4b8e-a335-e394d8bbc892",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "04016570-9b57-4e33-a15b-4794f03cc220",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "39bc5bdc-fda2-4210-a9e8-0b0b4e5f3beb",
-      "name" : "family name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${familyName}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "lastName",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "family_name",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "7453b8ff-f818-4915-a385-0c3e6fac7960",
+      "id" : "00007a29-23f1-4257-b76e-9eaad73f1540",
       "name" : "locale",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-attribute-mapper",
@@ -902,18 +849,85 @@
         "claim.name" : "locale",
         "jsonType.label" : "String"
       }
+    }, {
+      "id" : "158baae7-60e9-4533-846e-ceb1025c77bb",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "88c2964d-416c-4b3f-8f55-dfe5efcc1ab9",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "277f8371-bcba-41b7-9116-35a4c0c776e3",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "85d1f180-9669-4d35-b1b7-e527abb8b307",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "dbbf40ee-186b-4d7f-9bbe-70118e664b15",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
     } ],
     "useTemplateConfig" : false,
     "useTemplateScope" : false,
     "useTemplateMappers" : false
   }, {
-    "id" : "eb9f959f-5ad9-419a-8ba3-0ebda9e44d93",
+    "id" : "3a12f2df-23b1-4cb8-8452-c89b98b32e68",
     "clientId" : "Testrealm-realm",
     "name" : "Testrealm Realm",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "a93fe371-170d-461a-96f5-6a6e1b9726dd",
+    "secret" : "1324d1b0-6575-40d5-a76c-3e00514d8f21",
     "redirectUris" : [ ],
     "webOrigins" : [ ],
     "notBefore" : 0,
@@ -929,44 +943,7 @@
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : 0,
     "protocolMappers" : [ {
-      "id" : "d13a2812-be47-475b-b252-ba02d67720fd",
-      "name" : "role list",
-      "protocol" : "saml",
-      "protocolMapper" : "saml-role-list-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "single" : "false",
-        "attribute.nameformat" : "Basic",
-        "attribute.name" : "Role"
-      }
-    }, {
-      "id" : "9a5e88f7-0e3a-43b8-aec5-3d64ebcb68e4",
-      "name" : "full name",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-full-name-mapper",
-      "consentRequired" : true,
-      "consentText" : "${fullName}",
-      "config" : {
-        "id.token.claim" : "true",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "id" : "3953e6fe-ee44-4de5-ab03-4840153db166",
-      "name" : "username",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usermodel-property-mapper",
-      "consentRequired" : true,
-      "consentText" : "${username}",
-      "config" : {
-        "userinfo.token.claim" : "true",
-        "user.attribute" : "username",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "20dc5c72-0717-475e-9733-48bc9737713c",
+      "id" : "857a9f34-7b60-4536-9735-901358f3a2a3",
       "name" : "family name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -981,7 +958,33 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "75d71771-fb15-482c-8eb2-cc1e761b8c0d",
+      "id" : "763bf95e-5745-4c28-aa9a-41009e54c2eb",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cb7b1760-c343-4d0b-b3a3-7f0e398280b5",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "5defbc43-811c-4db5-818e-67fb6aa652a4",
       "name" : "email",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -996,7 +999,18 @@
         "jsonType.label" : "String"
       }
     }, {
-      "id" : "8c419c8b-98cf-4047-9ade-1d1ad6e0e7fc",
+      "id" : "abac25c3-44e0-4604-85d8-0179f7db0e8c",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "90b39935-4f7b-4681-8f70-d8c5cc780228",
       "name" : "given name",
       "protocol" : "openid-connect",
       "protocolMapper" : "oidc-usermodel-property-mapper",
@@ -1018,7 +1032,9 @@
   "clientTemplates" : [ ],
   "browserSecurityHeaders" : {
     "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
     "xFrameOptions" : "SAMEORIGIN",
+    "xXSSProtection" : "1; mode=block",
     "contentSecurityPolicy" : "frame-src 'self'"
   },
   "smtpServer" : { },
@@ -1028,14 +1044,92 @@
   "adminEventsEnabled" : false,
   "adminEventsDetailsEnabled" : false,
   "components" : {
-    "org.keycloak.keys.KeyProvider" : [ {
-      "id" : "8da4e883-3e60-44e3-86e3-adb3945a0236",
-      "name" : "rsa",
-      "providerId" : "rsa",
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "093d7055-5c35-4ff7-afbe-6e02c84bdf4d",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "3439fc66-1aaa-442e-b68e-f91f1c230b56",
+      "name" : "Allowed Client Templates",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "77c99615-deb6-4d7a-bce7-27b16d75b86b",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "privateKey" : [ "MIIEpQIBAAKCAQEA3KMHsdprpCCzeSlXmjDmRRWTpTg+4f7JEcxegKSmjm7prFGEHvLUMGBFOuqw0CTLBXjjti60RPD+TfE656nJPKsQmRbbDdcqAdnmqrc3N9mp+mW/Qln2WwWOiysSnMOaZIqVMwzL8zJbiB0ekGmCgkvY9wReKFZ/29RbfTCTROFXlNDB2rU1HvVdVPDYIkK4x2UzVUUogc2M60TAAWFNyr6Qo7w0SNzzNC9DoJisUZXNJFLVwXAgV7WedE/XQyb4NRrTSSkRmNTo3BPsVXhZfzfYqNGUkbgl07Nh8PZpYh9zbO/cPRdmjdMX4HUG3M1Xb9QnZ5WWaCGv19XC3LlOkQIDAQABAoIBAFOgV2JJ71KeMmhSCyoeLqkwrG2LDAqMj5l3ZLpNrfN+hoMRwooYb+SGGLdkDPBXgbvpPiXnPdyDm1/fdvwnlmawT/I2f4CXdQyOkqdSGlPI5GxL9Fopzv5g9M463Ssd2H8TJ8nZp9Pd2mOU5ejGlPjd1raJqUaQwpWHv8WLi8YnDujOFAWhnRtzMNhKoiJ+QW5KSArRy2gn8yK6kVMOEm7OzwDG3bRQk0TClDZr3/8XD5XMSThBEtE2zkgd5WeXVmq3uqZEHb3FS1Mu5VnLPYedO09vTuKL3gFWJ1zrJigORIhP6oB6qBXtpNPBODrvkwBA+ciYPpy5iu7DLHLymaECgYEA70cREGuSZtN8wFGIIq/4i8H0y6gJp/qMP8ytnYdi7r1pteWp00cvZuQ+sT5R3lwqQPtosVFd+eJEA/vkvE4VxPqM/xWFkphGgAoK8Nj/2qC5MXQLpO0bX2YUlw0MnOC/g/FA9DZ6nCA+v3UG22JAHjoLWZKU0DDsrUHrgLSEIvsCgYEA7A51xS7vAB+bHVkzgUlkRXYbVhAReNcx2YARMqko8K/SsTFwIzhw3vPJEcFWfGMq7BQuK/nmVr/glUmLiGQoY3B+cDaelyPQBskGgOEiGO80AgPv61YtIqIt1P/raoZGqMH3Gfwrv8lI4JvY5gPUO3AdyV0abHYc8FyNDzlIvuMCgYEA7k9hd3EsBq1r+j85zxJkAQ3TuWJK+7pWJNS9tb85kX2k4z0xvvOPCnMY3X6sG0K/8qhyxOe9KTtpcm5WihVbKSxBcW0F89MlpDBcZTQ63oxk5hQl5MUiFgmdSDP+8+AD3m1Ru+jmhMi4tgbgJW/dXD2DQFr1S8TudEDLRQyE7jECgYEA1h/nxI3mTn5c/ipEBirEwh14foDk2HCbz2fUMdgwQuO6gvENf2VbPWJ2KZzvDrYF4VAM8eclgdtbpQ+pencgC9OnXbKt+PuLYBxJwe52N5gD3TAlGZx6JMhoOqZKrb5PqhUISJHuPXIgoV29Sih/A8uXuWiy51/csEvDyON1kXECgYEAiSDEAd7w6WnJv6s/e1yMi3CLGTTqPue3G5Er1OpQajTXqgMeARVwhA0GICfD6v3CXFNT5rPl6VJ/7AHyGI9m9oAWFURS/1BsVNu7tLPENntG1xThRTUJpl2a+yHQmWe7C/CB4Lm08C0Nwwsqk7pbqIFjA0CQc2vqOX8aGNgxQmI=" ],
-        "certificate" : [ "MIICmzCCAYMCBgFYAN63aTANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZtYXN0ZXIwHhcNMTYxMDI2MTIwMDQ1WhcNMjYxMDI2MTIwMjI1WjARMQ8wDQYDVQQDDAZtYXN0ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDcowex2mukILN5KVeaMOZFFZOlOD7h/skRzF6ApKaObumsUYQe8tQwYEU66rDQJMsFeOO2LrRE8P5N8Trnqck8qxCZFtsN1yoB2eaqtzc32an6Zb9CWfZbBY6LKxKcw5pkipUzDMvzMluIHR6QaYKCS9j3BF4oVn/b1Ft9MJNE4VeU0MHatTUe9V1U8NgiQrjHZTNVRSiBzYzrRMABYU3KvpCjvDRI3PM0L0OgmKxRlc0kUtXBcCBXtZ50T9dDJvg1GtNJKRGY1OjcE+xVeFl/N9io0ZSRuCXTs2Hw9mliH3Ns79w9F2aN0xfgdQbczVdv1CdnlZZoIa/X1cLcuU6RAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAIfaf5nFRcZWMQbTylv8r1U4qhKYsqDJwyaCcMNpcSxLpYgyJSzWr4DqZzUl+YIp2lVdiEK0RwGy2ZFwyKkUk/oz6PLC4tBsPIHFK0AuOg8hC0E76ql7UthEA+mH9S1g3qOsaWeBOdJg+JWDU86HlCW050mD6oNQEW5dZiWyX4rh0+xJg8ZxM2sWCI2aM6CPYkWEYP3Opv9VtndgGD8ZnbYyDqeRqHcuskAsqrrRLU6ADr3ZweEOlgitj0JBDOtaDiDcUwTa9qcPlDJSbqnR+sjUM2OLdqWkl0vVCKnhf9kxzTH1TbnWKE7KOGH/+aeO5dzBnGJ/hFfZ1eZhGEpVVDo=" ],
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "saml-role-list-mapper" ],
+        "consent-required-for-all-mappers" : [ "true" ]
+      }
+    }, {
+      "id" : "b104116e-5794-4266-8f3d-146b7f542041",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "b50cb56d-e8f0-434d-b39d-a9c5ff98a66e",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "oidc-full-name-mapper", "saml-role-list-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper" ],
+        "consent-required-for-all-mappers" : [ "true" ]
+      }
+    }, {
+      "id" : "bb5c077c-7f92-484b-8d7e-b169cf61cdcc",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "bc5bcd4e-b642-45e2-911c-eeafb0406aa7",
+      "name" : "Allowed Client Templates",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "d6263eaf-8f70-4952-962e-11d4c9cd93d5",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "0bab4cb4-5cd9-4e59-bf53-b6db56ce5f56",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAtgJ0PrVv6p5MVn1txQJFm9UQtrLOpNsjfOcUeIXCKQQhEnAZ9LccONXyKDpfYfrVEQ6WpWFjrFKpRo22kC4yVY2gYmEfcm3aSMIDZ39NGlWyXGJYPzMJcXlzIZlAOxsKEdJccTVYeHglFUZZvf6Tc/g+N51j0e418p4EoufgeKjqETM2TwXvOJpAAstQsIqqlGVW0n/ku55q+khoZHkCkSzVdR/glBjm8L3qJscbmV4fHl4VdKvFhqQuWpDZy5oM3zNIup0alE9suvi3xZJLWZrBUwM0hE/MpoBz4/+gnBvZ1zPnz+AHJ41AJOl4+duPOjg2z2pPjEU/LNm+96A0jwIDAQABAoIBAQCJVHazbiEArOo6hC9T6+/rsasHvwiuWO6A6raGbZ5fZk8x40WiYJs5wywQ8GJRwnoLga9nH4GeX0x8AKdUSJcP+GmgcVnR9FM0fLcm22WozipjDI07Ol4QsauOGVzee/twEQJRJQgY9cY9NDS4Z6KIaTFAs0/C8XLhGhuzczPqtXsGWSES3NBSQMtn5PW6zl0gwUtFOAUf/pPHBGWwo8cxSBNsQgV4CG8D4cl6Q3N+2rjOcuj7C+MvoGyzhR+10qgNP/kWBHN05OmXT0T9RAbJRpqNgQZ6w6VRSKs1z8BBLs6bW7lGAZtd60m851z/YMgvtPE9AzlHLJU93I6ekOBBAoGBANtPMFR0nJo2QORp+juBuIrmLDqRfHV6+u8a8F8YrK1f+3M7JhXk0ZWDxfQK17+F0rQwo4yL7DCfp1qfGOW3Cg9MoCIhnoN17KGB36ssH68FpH4mf0Ul0FSTbLoD01OLjkk5C5G6NfUXpApLKkz4CslwWv8cfhKThoyhi5ZpG3XhAoGBANR1wKPCeS2V6PHwq11c0DAYq+KtZLr02R6K67qO4UZau2+8ocHkzfu3yyWeYFhKU7g0oTzNM7OiwuJCZ3VKGLDyj/hnIaw39BXUEDCSbB+gdL++WEBMQi7EkTB5aKZKnlRMk2zsB/b9FskkUQUyMjpJAbSpreumAtyMZ2ThCxhvAoGAaJwsZIy/SnwIlivLFel5up+yhzlwkaVY3wcNk370lzrKeZvEPftI0bXqjc9CPHQ8HoF48gioYEU3ke2D9cdKwCN/2ugIcZKljiCiLUc90cGyRg5c9QHljwJHga9jdV2DQIA6eYfGRyPAtrxF8DL9CjtS3I+dv4SpUJmaOOPoGmECgYBJdpHuzf7ioVRT3BkVBlPCXbWJgtUyxBkTM4wBDQieMB9hqoLwLXKAGHQ5BMNhpAnAxwn9oSLAeYYTgEyPxNg2zxizFs4Q46QVrCcQ9IBIi03zQxj22qeDzlo5vbFO1rxaf8P2RMMYRzkKwfD17/5oIvhhBM7rjZKtuirCOgKBJwKBgEE+18pe0GFdfsHkJLXfLzISkKZEFD7UYYPOZT/CMoOuUPl1ftLD8sxa+qfWI4CCVdACIq9VbY3rEA3HoNvOMptY40+H4myONczbJyVNbtyr8/8bhghIfycu9BktVF1NryE3jhp+0pJZ0VnSUUGuNz9O/AWcuMan4GwQdIiBa29C" ],
+        "certificate" : [ "MIICmzCCAYMCBgFcP+7/ZDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZtYXN0ZXIwHhcNMTcwNTI1MTQwNTQ2WhcNMjcwNTI1MTQwNzI2WjARMQ8wDQYDVQQDDAZtYXN0ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2AnQ+tW/qnkxWfW3FAkWb1RC2ss6k2yN85xR4hcIpBCEScBn0txw41fIoOl9h+tURDpalYWOsUqlGjbaQLjJVjaBiYR9ybdpIwgNnf00aVbJcYlg/MwlxeXMhmUA7GwoR0lxxNVh4eCUVRlm9/pNz+D43nWPR7jXyngSi5+B4qOoRMzZPBe84mkACy1CwiqqUZVbSf+S7nmr6SGhkeQKRLNV1H+CUGObwveomxxuZXh8eXhV0q8WGpC5akNnLmgzfM0i6nRqUT2y6+LfFkktZmsFTAzSET8ymgHPj/6CcG9nXM+fP4AcnjUAk6Xj52486ODbPak+MRT8s2b73oDSPAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADJufY/QjUncqbYY3DHnXoaTCTsTHWZ3g+RmiQIqrVxYKLd1e8iJ2RKdtXQ+tQgaiaDXwjj+y2dfEBQQqp/bHPL+vWDRQmn59PQeZfncmc8rF5KqPQuxn/Ln/+ZdX8ORrHq4TKlDw94XTi39mviQpAmnJqJ5nWFVjSm+tnwHyV2uuRhJqaTQJYrBv02nfIFR3R+m8neCBeVmQ8SM/YifccV1Nwc0ldA+QqYL5XOKGyrqUkKv0mmi8DMjVCpBB6uSGvFp993fPsAeRkUk4OPt4Th9IAh0vtaAQU0foLYuEeOKxH0Z3wA3VPvTHbLELuQlLTBIZVAmtP8mpY7A0MAxIDI=" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "6f1ae968-6ea9-4a0f-afa9-aff392f5514b",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "69d15d16-d6ca-491c-b4a8-cbdb0380af82" ],
+        "secret" : [ "1VhAXlEjA32KJNjKroNvkzffTjZKRoL1EhgtzzcDsAs" ],
         "priority" : [ "100" ]
       }
     } ]
@@ -1043,7 +1137,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "393812b5-79e0-4e58-8c31-8e355e9690d5",
+    "id" : "5f796053-d6e2-4e36-a763-7c54a4ee1996",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1069,7 +1163,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "88059c82-016b-476d-afa9-1b9be8eb80d8",
+    "id" : "d00e6cf4-4071-4138-8c59-213662764c43",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1089,7 +1183,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "83264d33-085c-4d09-8bd3-9089128d59c6",
+    "id" : "0badb0c3-a150-43a6-bbb2-6ddd05f98ce1",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1121,7 +1215,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "57d7978f-8bb2-4c0a-bc3d-6f5a7203dd76",
+    "id" : "51d389e0-9dfd-49a6-91ec-ba9e51282b73",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1141,7 +1235,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "77bf42ad-329a-48bf-9b51-b2e7b7424f4d",
+    "id" : "2d0c759d-fd5d-4b94-9411-e5b29a2687f7",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1167,7 +1261,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "99238994-d3d9-412f-babc-e153a7018e65",
+    "id" : "3fb43da4-8152-46ea-8fe3-9c03ebefeac9",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1195,7 +1289,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "6f598a76-5d89-46c8-be1f-decbf8c3914f",
+    "id" : "8b5f19ee-b045-44d3-b633-ae2ba2b956a1",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1215,7 +1309,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "8270c84e-3a0c-400c-9922-05b98df7829b",
+    "id" : "49c2335e-9f89-4447-9fff-b64f8aef609d",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1230,7 +1324,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "43dca37a-ee2f-4501-8533-fc6292a2dcc0",
+    "id" : "95b2b28e-5443-4f69-91fe-27770f85419f",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1262,7 +1356,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "2ae25fa6-0057-4952-a750-1b7820ae7661",
+    "id" : "f7421916-c653-4a0d-b2f3-631958357695",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1294,7 +1388,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "e03be460-6fe4-4faa-a983-b00c06896f05",
+    "id" : "cc521d3e-82a7-4cad-9292-d6a123b0caed",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1309,13 +1403,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "e4a4bccb-4f8e-45ef-bc38-365166de46c0",
+    "id" : "ea148fc3-0151-4c4e-b19b-a5b25076357b",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "aba390b2-69df-4913-8101-055f9a587aa6",
+    "id" : "19472507-ab88-451e-9764-f7a9a638988a",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"
@@ -1363,18 +1457,20 @@
   "resetCredentialsFlow" : "reset credentials",
   "clientAuthenticationFlow" : "clients",
   "attributes" : {
+    "_browser_header.xXSSProtection" : "1; mode=block",
     "_browser_header.xFrameOptions" : "SAMEORIGIN",
-    "failureFactor" : "30",
     "quickLoginCheckMilliSeconds" : "1000",
-    "maxDeltaTimeSeconds" : "43200",
     "displayName" : "Keycloak",
+    "_browser_header.xRobotsTag" : "none",
+    "maxFailureWaitSeconds" : "900",
+    "displayNameHtml" : "<div class=\"kc-logo-text\"><span>Keycloak</span></div>",
+    "minimumQuickLoginWaitSeconds" : "60",
+    "failureFactor" : "30",
+    "maxDeltaTimeSeconds" : "43200",
     "_browser_header.xContentTypeOptions" : "nosniff",
     "bruteForceProtected" : "false",
-    "maxFailureWaitSeconds" : "900",
     "_browser_header.contentSecurityPolicy" : "frame-src 'self'",
-    "minimumQuickLoginWaitSeconds" : "60",
-    "displayNameHtml" : "<div class=\"kc-logo-text\"><span>Keycloak</span></div>",
     "waitIncrementSeconds" : "60"
   },
-  "keycloakVersion" : "2.3.0.Final"
+  "keycloakVersion" : "3.1.0.Final"
 }

--- a/build-contracts/keycloak-setup/export/master-users-0.json
+++ b/build-contracts/keycloak-setup/export/master-users-0.json
@@ -1,16 +1,16 @@
 {
   "realm" : "master",
   "users" : [ {
-    "id" : "014a45ff-9f29-4ff0-9d65-0d2557cad684",
-    "createdTimestamp" : 1477483346047,
+    "id" : "d0ed2abc-f8c8-4256-a17a-8767e543d272",
+    "createdTimestamp" : 1495721246950,
     "username" : "admin",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
     "credentials" : [ {
       "type" : "password",
-      "hashedSaltedValue" : "W8HiJ0H6dPl8B+vUDxwDBj3iXkoX2bbmgPfsiSmVHAZXlUNrTRbY9sIpP9o9eVlQykWgJCh1aseaNBUzOCmM4Q==",
-      "salt" : "3sleNqX/b71P9b4A7ms4Fw==",
+      "hashedSaltedValue" : "ZALbBDHdzQEqysXcp37xSdq+Y16GzoNt69KGZpl4MhjjenERmJOEjjveMC1B079kSorSMDrMZMbxgsE+4VVSYw==",
+      "salt" : "TleuNJn9nchuXDvU3lPnyQ==",
       "hashIterations" : 20000,
       "counter" : 0,
       "algorithm" : "pbkdf2",
@@ -18,10 +18,11 @@
       "period" : 0,
       "config" : { }
     } ],
+    "disableableCredentialTypes" : [ "password" ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "admin", "offline_access" ],
+    "realmRoles" : [ "uma_authorization", "offline_access", "admin" ],
     "clientRoles" : {
-      "account" : [ "manage-account", "view-profile" ]
+      "account" : [ "view-profile", "manage-account" ]
     },
     "groups" : [ ]
   } ]

--- a/build-contracts/keycloak-setup/keycloak-admin.json
+++ b/build-contracts/keycloak-setup/keycloak-admin.json
@@ -1,0 +1,7 @@
+{
+  "server-url" : "http://localhost:8080/auth",
+  "realm" : "Master",
+  "min-time-between-jwks-requests" : 0,
+  "resource" : "master-realm",
+  "public-client" : true
+}

--- a/build-contracts/keycloak-setup/keycloak-admin.json
+++ b/build-contracts/keycloak-setup/keycloak-admin.json
@@ -3,5 +3,6 @@
   "realm" : "Master",
   "min-time-between-jwks-requests" : 0,
   "resource" : "master-realm",
-  "public-client" : true
+  "bearer-only" : true,
+  "secret": "0ec9e23a-4b62-4b93-ba2c-01b1c0f28c29"
 }

--- a/build-contracts/keycloak-setup/keycloak-admin.json
+++ b/build-contracts/keycloak-setup/keycloak-admin.json
@@ -4,5 +4,6 @@
   "min-time-between-jwks-requests" : 0,
   "resource" : "master-realm",
   "bearer-only" : true,
+  "client-id": "master-realm",
   "secret": "0ec9e23a-4b62-4b93-ba2c-01b1c0f28c29"
 }

--- a/build-contracts/keycloak-setup/keycloak-test1.json
+++ b/build-contracts/keycloak-setup/keycloak-test1.json
@@ -1,0 +1,7 @@
+{
+  "server-url" : "http://localhost:8080/auth",
+  "realm" : "Testrealm",
+  "min-time-between-jwks-requests" : 0,
+  "resource" : "openid1",
+  "public-client" : true
+}

--- a/build-contracts/keycloak-setup/package.json
+++ b/build-contracts/keycloak-setup/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "openidc-keycloak-test-setup",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "./node_modules/.bin/mocha ./"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "chai": "4.0.0",
+    "keycloak-auth-utils": "3.1.0",
+    "mocha": "3.4.2"
+  }
+}

--- a/build-contracts/keycloak-setup/package.json
+++ b/build-contracts/keycloak-setup/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "chai": "4.0.0",
-    "keycloak-auth-utils": "3.1.0",
+    "keycloak-auth-utils": "git+https://github.com/keycloak/keycloak-nodejs-auth-utils#af667875a4ce4942a89b13c471ef3da627ab7cfb",
     "mocha": "3.4.2"
   }
 }

--- a/build-contracts/keycloak-setup/spec.js
+++ b/build-contracts/keycloak-setup/spec.js
@@ -9,6 +9,20 @@ describe("Admin access", function() {
 
   describe("Authenticate as admin:openidctest", function() {
 
+    var grant;
+
+    it("Gets a token", function() {
+      const config = new KeycloakAuth.Config('./keycloak-admin.json');
+      const manager = new KeycloakAuth.GrantManager(config);
+
+      return manager.obtainDirectly('admin', 'openidctest').then((g) => grant = g);
+    });
+
+    it("Contains interesting stuff", function() {
+      expect(grant).to.be.an('object').and.have.a.property('access_token');
+      console.log(JSON.stringify(grant.access_token.content, null, '  '));
+    });
+
   });
 
 

--- a/build-contracts/keycloak-setup/spec.js
+++ b/build-contracts/keycloak-setup/spec.js
@@ -18,19 +18,23 @@ describe("Testrealm access (if import passed)", function() {
 
   describe("Authenticate as test1:test1", function() {
 
-    var token;
+    var grant;
 
-    it("Gets a token", function(done) {
+    it("Gets a token", function() {
       const config = new KeycloakAuth.Config('./keycloak-test1.json');
       const manager = new KeycloakAuth.GrantManager(config);
 
-      var auth = manager.obtainDirectly('test1', 'test1')
-        .then((grant) => expect(grant).to.be.an('object').and.have.a.property('access_token'))
-        .then((access) => token = access);
+      return manager.obtainDirectly('test1', 'test1').then((g) => grant = g);
     });
 
     it("Contains interesting stuff", function() {
-      console.log(JSON.stringify(token, null, '  '));
+      expect(grant).to.be.an('object').and.have.a.property('access_token');
+      console.log(JSON.stringify(grant.access_token.content, null, '  '));
+    });
+
+    it("Contains more interesting stuff", function() {
+      expect(grant).to.have.a.property('id_token');
+      expect(grant).to.have.a.property('refresh_token');
     });
 
   });

--- a/build-contracts/keycloak-setup/spec.js
+++ b/build-contracts/keycloak-setup/spec.js
@@ -1,0 +1,38 @@
+const expect = require('chai').expect;
+
+// see https://github.com/keycloak/keycloak-nodejs-auth-utils/blob/master/test/integration/grant-manager-spec.js
+const KeycloakAuth = require('keycloak-auth-utils');
+
+
+
+describe("Admin access", function() {
+
+  describe("Authenticate as admin:openidctest", function() {
+
+  });
+
+
+});
+
+describe("Testrealm access (if import passed)", function() {
+
+  describe("Authenticate as test1:test1", function() {
+
+    var token;
+
+    it("Gets a token", function(done) {
+      const config = new KeycloakAuth.Config('./keycloak-test1.json');
+      const manager = new KeycloakAuth.GrantManager(config);
+
+      var auth = manager.obtainDirectly('test1', 'test1')
+        .then((grant) => expect(grant).to.be.an('object').and.have.a.property('access_token'))
+        .then((access) => token = access);
+    });
+
+    it("Contains interesting stuff", function() {
+      console.log(JSON.stringify(token, null, '  '));
+    });
+
+  });
+
+});

--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -21,6 +21,8 @@
 	OIDCRemoteUserClaim sub
 	OIDCPassClaimsAs environment
 
+	OIDCInfoHook userinfo
+
 	# See fast if we accumulate state cookies
 	LimitRequestFieldSize 4096
 

--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -5,19 +5,24 @@
 	ErrorLog /proc/self/fd/1
 	CustomLog /proc/self/fd/2 combined
 
-	OIDCProviderMetadataURL http://keycloak:8080/auth/realms/Testrealm/.well-known/openid-configuration
-	#OIDCRedirectURI http://openidc/oauth2callback
-	OIDCRedirectURI http://openidc/protected/redirect_uri
+	RequestHeader set X-Forwarded-Proto http
+	ProxyPreserveHost On
+	ProxyPass "/auth/"  "http://keycloak:8080/auth/"
+	<Location "/auth/">
+		OIDCUnAuthAction pass
+	</Location>
+
+	OIDCProviderMetadataURL http://openidc/auth/realms/Testrealm/.well-known/openid-configuration
+	OIDCRedirectURI /protected/redirect_uri
 	OIDCDefaultURL http://openidc/protected/
-	OIDCCryptoPassphrase 0123456789
-	OIDCClientID testclient
-	OIDCClientSecret 12816dc7-cf40-4abc-8df7-581e56930cf5
+	OIDCCryptoPassphrase in-production-this-is-something-random
+	OIDCClientID openid1
 
-	OIDCSessionType server-cache:persistent
-
-	OIDCRemoteUserClaim email
-	OIDCScope "openid email"
+	OIDCRemoteUserClaim sub
 	OIDCPassClaimsAs environment
+
+	# See fast if we accumulate state cookies
+	LimitRequestFieldSize 4096
 
 	Header setifempty Cache-Control "max-age=0, must-revalidate"
 

--- a/build-contracts/openidc/Dockerfile
+++ b/build-contracts/openidc/Dockerfile
@@ -4,5 +4,7 @@ COPY 000-default.conf conf/
 RUN echo "Include conf/000-default.conf" >> conf/httpd.conf
 
 RUN sed -i 's/#LoadModule cgid_module/LoadModule cgid_module/' conf/httpd.conf \
+  && sed -i 's/#LoadModule proxy_module/LoadModule proxy_module/' conf/httpd.conf \
+  && sed -i 's/#LoadModule proxy_http_module/LoadModule proxy_http_module/' conf/httpd.conf \
   && sed -i '1s;^#;#!/usr/bin/perl;' cgi-bin/printenv \
   && chmod a+x cgi-bin/printenv cgi-bin/printenv

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -2,9 +2,9 @@
 # https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
 FROM httpd:2.4.25@sha256:4612fba4347bd87eaeecd5c522d844f26cc4065b45eef9291277497946b7a86c
 
-ENV OPENIDC_VERSION v2.2.0
+ENV OPENIDC_VERSION 6f4629bf48cbc0e077f079c343b7a42b6143b35b
 ENV OPENIDC_VERSION_TGZ_URL https://github.com/pingidentity/mod_auth_openidc/archive/$OPENIDC_VERSION.tar.gz
-ENV OPENIDC_VERSION_TGZ_SHA1 2b908e1bcd4bc8894b08cb271ad92e0de5b05aef
+ENV OPENIDC_VERSION_TGZ_SHA1 af49e35122cf590140aa815f150fbece0730863e
 
 ENV CJOSE_VERSION 0.4.1
 ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.1.0/libcjose_$CJOSE_VERSION-1_amd64.deb

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -2,9 +2,9 @@
 # https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
 FROM httpd:2.4.25@sha256:4612fba4347bd87eaeecd5c522d844f26cc4065b45eef9291277497946b7a86c
 
-ENV OPENIDC_VERSION v2.1.6
+ENV OPENIDC_VERSION v2.2.0
 ENV OPENIDC_VERSION_TGZ_URL https://github.com/pingidentity/mod_auth_openidc/archive/$OPENIDC_VERSION.tar.gz
-ENV OPENIDC_VERSION_TGZ_SHA1 5f45c6a6b5111f007fbfd52efd9ade654bfee905
+ENV OPENIDC_VERSION_TGZ_SHA1 2b908e1bcd4bc8894b08cb271ad92e0de5b05aef
 
 ENV CJOSE_VERSION 0.4.1
 ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.1.0/libcjose_$CJOSE_VERSION-1_amd64.deb

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -2,9 +2,9 @@
 # https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
 FROM httpd:2.4.25@sha256:72b55a7c15a4ee3d56ff19f83b57b82287714f91070b1f556a54e90da5eee3fa
 
-ENV OPENIDC_VERSION 6f4629bf48cbc0e077f079c343b7a42b6143b35b
+ENV OPENIDC_VERSION v2.3.0
 ENV OPENIDC_VERSION_TGZ_URL https://github.com/pingidentity/mod_auth_openidc/archive/$OPENIDC_VERSION.tar.gz
-ENV OPENIDC_VERSION_TGZ_SHA1 af49e35122cf590140aa815f150fbece0730863e
+ENV OPENIDC_VERSION_TGZ_SHA1 a958d14d38a9800cf131cbd030dadb0bfbd6e778
 
 ENV CJOSE_VERSION 0.4.1
 ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.1.0/libcjose_$CJOSE_VERSION-1_amd64.deb

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -6,9 +6,9 @@ ENV OPENIDC_VERSION v2.3.0
 ENV OPENIDC_VERSION_TGZ_URL https://github.com/pingidentity/mod_auth_openidc/archive/$OPENIDC_VERSION.tar.gz
 ENV OPENIDC_VERSION_TGZ_SHA1 a958d14d38a9800cf131cbd030dadb0bfbd6e778
 
-ENV CJOSE_VERSION 0.4.1
-ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.1.0/libcjose_$CJOSE_VERSION-1_amd64.deb
-ENV CJOSE_DEB_SHA1 21a2aa687c7e151a4f72cae096e91b857da5294f
+ENV CJOSE_VERSION 0.5.1
+ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.3.0/libcjose0_$CJOSE_VERSION-1.jessie.1_amd64.deb
+ENV CJOSE_DEB_SHA1 cad77328cf33319e85267a1e9f804912aed3bb5d
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -1,6 +1,6 @@
 
 # https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
-FROM httpd:2.4.25@sha256:4612fba4347bd87eaeecd5c522d844f26cc4065b45eef9291277497946b7a86c
+FROM httpd:2.4.25@sha256:72b55a7c15a4ee3d56ff19f83b57b82287714f91070b1f556a54e90da5eee3fa
 
 ENV OPENIDC_VERSION 6f4629bf48cbc0e077f079c343b7a42b6143b35b
 ENV OPENIDC_VERSION_TGZ_URL https://github.com/pingidentity/mod_auth_openidc/archive/$OPENIDC_VERSION.tar.gz

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -9,6 +9,7 @@ ENV OPENIDC_VERSION_TGZ_SHA1 a958d14d38a9800cf131cbd030dadb0bfbd6e778
 ENV CJOSE_VERSION 0.5.1
 ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.3.0/libcjose0_$CJOSE_VERSION-1.jessie.1_amd64.deb
 ENV CJOSE_DEB_SHA1 cad77328cf33319e85267a1e9f804912aed3bb5d
+ENV CJOSE_DEV_DEB_URL https://mod-auth-openidc.org/download/libcjose-dev_$CJOSE_VERSION-1~jessie+1_amd64.deb
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -39,6 +40,9 @@ RUN depsRuntime=" \
 	&& echo "$CJOSE_DEB_SHA1 libcjose.deb" | sha1sum -c - \
 	&& dpkg -i libcjose.deb \
 	&& rm libcjose.deb \
+	&& curl -SL "$CJOSE_DEV_DEB_URL" -o libcjose-dev.deb \
+	&& dpkg -i libcjose-dev.deb \
+	&& rm libcjose-dev.deb \
 	&& curl -SL "$OPENIDC_VERSION_TGZ_URL" -o mod_auth_openidc-$OPENIDC_VERSION.tar.gz \
 	&& echo "$OPENIDC_VERSION_TGZ_SHA1 mod_auth_openidc-$OPENIDC_VERSION.tar.gz" | sha1sum -c - \
 	&& mkdir -p src/mod_auth_openidc \

--- a/openidc-jessie/Dockerfile
+++ b/openidc-jessie/Dockerfile
@@ -3,14 +3,14 @@ MAINTAINER hzandbelt@pingidentity.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates libjansson4 apache2 libhiredis0.10
 
-ENV CJOSE_VERSION 0.4.1
-ENV CJOSE_PKG libcjose_${CJOSE_VERSION}-1_amd64.deb
-RUN curl -s -L -o ~/${CJOSE_PKG} https://mod-auth-openidc.org/download/${CJOSE_PKG}
+ENV CJOSE_VERSION 0.5.1
+ENV CJOSE_PKG libcjose0_${CJOSE_VERSION}-1.jessie.1_amd64.deb
+RUN curl -s -L -o ~/${CJOSE_PKG} https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.3.0/${CJOSE_PKG}
 RUN dpkg -i ~/${CJOSE_PKG} && echo ok || echo ko
 
-ENV MOD_AUTH_OPENIDC_VERSION 2.1.6
-ENV MOD_AUTH_OPENIDC_PKG libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1_amd64.deb
-RUN curl -s -L -o ~/${MOD_AUTH_OPENIDC_PKG} https://mod-auth-openidc.org/download/${MOD_AUTH_OPENIDC_PKG}
+ENV MOD_AUTH_OPENIDC_VERSION 2.3.0
+ENV MOD_AUTH_OPENIDC_PKG libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1.jessie.1_amd64.deb
+RUN curl -s -L -o ~/${MOD_AUTH_OPENIDC_PKG} https://github.com/pingidentity/mod_auth_openidc/releases/download/v${MOD_AUTH_OPENIDC_VERSION}/${MOD_AUTH_OPENIDC_PKG}
 RUN dpkg -i ~/${MOD_AUTH_OPENIDC_PKG} && echo ok || echo ko
 
 ADD 000-default.conf /etc/apache2/sites-available/


### PR DESCRIPTION
Before the support for https://github.com/pingidentity/mod_auth_openidc/wiki/Single-Page-Applications we've used a special `Location` that sort of supports session info:
```
    Header always set Access-Control-Allow-Credentials "true"
    Header always set Access-Control-Allow-Origin "null"
    ErrorDocument 401 "{\"authenticated\": false }"
    ErrorDocument 404 "{\"authenticated\": true }"
```
And to refresh we were using jQuery this way:
```
  jquery.ajax({
    url: opt.path,
    crossDomain: true,
    xhrFields: {
      withCredentials: true
    },
  })
```

Also we've always used Access Type "confidential" for the openid-connect client in Keycloak, but that seems to block token based auth.