### PR TITLE
Use httpd package from debian stretch instead of official httpd image

### DIFF
--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     # For local browser; you also need "openidc" in your hosts file
     ports:
       - "80:80"
+    command:
+      - -DLOGLEVEL=info
     volumes:
       - ./html-ajax:/var/www/html
   keycloak-setup:

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     ports:
       - "80:80"
     volumes:
-      - ./html-ajax:/usr/local/apache2/htdocs
+      - ./html-ajax:/var/www/html
   keycloak-setup:
     build: ./keycloak-setup
     links:

--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -1,6 +1,6 @@
 <VirtualHost *:80>
 	ServerAdmin webmaster@localhost
-	DocumentRoot htdocs/
+	DocumentRoot /var/www/html
 
 	ErrorLog /proc/self/fd/1
 	CustomLog /proc/self/fd/2 combined

--- a/build-contracts/openidc/Dockerfile
+++ b/build-contracts/openidc/Dockerfile
@@ -1,10 +1,11 @@
 FROM localhost:5000/reposoft/httpd-openidc
 
-COPY 000-default.conf conf/
-RUN echo "Include conf/000-default.conf" >> conf/httpd.conf
+COPY 000-default.conf sites-enabled/
 
-RUN sed -i 's/#LoadModule cgid_module/LoadModule cgid_module/' conf/httpd.conf \
-  && sed -i 's/#LoadModule proxy_module/LoadModule proxy_module/' conf/httpd.conf \
-  && sed -i 's/#LoadModule proxy_http_module/LoadModule proxy_http_module/' conf/httpd.conf \
-  && sed -i '1s;^#;#!/usr/bin/perl;' cgi-bin/printenv \
-  && chmod a+x cgi-bin/printenv cgi-bin/printenv
+RUN a2enmod \
+  headers \
+  cgid \
+  proxy \
+  proxy_http
+
+COPY printenv /usr/lib/cgi-bin

--- a/build-contracts/openidc/printenv
+++ b/build-contracts/openidc/printenv
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+print "Content-type: text/plain; charset=iso-8859-1\n\n";
+foreach my $var (sort(keys(%ENV))) {
+    my $val = $ENV{$var};
+    $val =~ s|\n|\\n|g;
+    $val =~ s|"|\\"|g;
+    print "${var}=\"${val}\"\n";
+}

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -1,14 +1,12 @@
-
-# https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
-FROM httpd:2.4.29@sha256:8ac08d0fdc49f2dc83bf5dab36c029ffe7776f846617335225d2796c74a247b4
+FROM debian:stretch-slim@sha256:ea42520331a55094b90f6f6663211d4f5a62c5781673935fe17a4dfced777029
 
 ENV OPENIDC_VERSION 2.3.3
-ENV OPENIDC_VERSION_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v$OPENIDC_VERSION/libapache2-mod-auth-openidc_$OPENIDC_VERSION-1.jessie.1_amd64.deb
-ENV OPENIDC_VERSION_DEB_SHA1 6470b08257f2c7483cdabed343fb2f715194627c
+ENV OPENIDC_VERSION_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v$OPENIDC_VERSION/libapache2-mod-auth-openidc_$OPENIDC_VERSION-1.stretch.1_amd64.deb
+ENV OPENIDC_VERSION_DEB_SHA1 453f04d38c90cbb60c914abbaf9a775ab8470a2a
 
 ENV CJOSE_VERSION 0.5.1
-ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.3.0/libcjose0_$CJOSE_VERSION-1.jessie.1_amd64.deb
-ENV CJOSE_DEB_SHA1 cad77328cf33319e85267a1e9f804912aed3bb5d
+ENV CJOSE_DEB_URL https://github.com/pingidentity/mod_auth_openidc/releases/download/v2.3.0/libcjose0_$CJOSE_VERSION-1.stretch.1_amd64.deb
+ENV CJOSE_DEB_SHA1 bffa341882615a24df357d8659d1d553afa46abe
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -16,8 +14,8 @@ RUN depsRuntime=" \
     libcurl3 ca-certificates \
     libpcre3 \
     libjansson4 \
-    libhiredis0.10 \
-    apache2-api-20120211 \
+    libhiredis0.13 \
+    apache2 \
   " \
   && depsBuild=" \
     curl \
@@ -26,16 +24,20 @@ RUN depsRuntime=" \
   && apt-get update \
   && apt-get install -y --no-install-recommends $depsRuntime \
   && apt-get install -y --no-install-recommends $depsBuild \
-  && rm -r /var/lib/apt/lists/* \
-  && curl -SL "$CJOSE_DEB_URL" -o libcjose.deb \
+  && curl -sLS "$CJOSE_DEB_URL" -o libcjose.deb \
   && echo "$CJOSE_DEB_SHA1 libcjose.deb" | sha1sum -c - \
   && dpkg -i libcjose.deb \
   && rm libcjose.deb \
-  && curl -SL "$OPENIDC_VERSION_DEB_URL" -o mod_auth_openidc-$OPENIDC_VERSION.deb \
+  && curl -sLS "$OPENIDC_VERSION_DEB_URL" -o mod_auth_openidc-$OPENIDC_VERSION.deb \
   && echo "$OPENIDC_VERSION_DEB_SHA1 mod_auth_openidc-$OPENIDC_VERSION.deb" | sha1sum -c - \
   && dpkg -i mod_auth_openidc-$OPENIDC_VERSION.deb \
+  && a2enmod auth_openidc \
   && rm mod_auth_openidc-$OPENIDC_VERSION.deb \
-  && ln -s /usr/lib/apache2/modules/mod_auth_openidc.so /usr/local/apache2/modules/mod_auth_openidc.so \
-  && apt-get purge -y --auto-remove $depsBuild
+  && apt-get purge -y --auto-remove $depsBuild \
+  && rm -rf /usr/share/man/man1 \
+  && rm -r /var/lib/apt/lists/* \
+  && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt
 
-RUN sed -i 's|LoadModule rewrite_module modules/mod_rewrite.so|LoadModule rewrite_module modules/mod_rewrite.so\nLoadModule auth_openidc_module modules/mod_auth_openidc.so|' conf/httpd.conf
+EXPOSE 80
+
+ENTRYPOINT ["apache2ctl", "-DFOREGROUND"]

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -38,6 +38,29 @@ RUN depsRuntime=" \
   && rm -r /var/lib/apt/lists/* \
   && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt
 
+# Configure logs as in https://github.com/docker-library/httpd/blob/master/2.4/Dockerfile
+# and disable some things that will probably not be needed with mod_auth_openidc
+
+RUN set -e; \
+  set -x; \
+  a2disconf serve-cgi-bin; \
+  a2dissite 000-default; \
+  a2dismod access_compat; \
+  sed -ri -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+    /etc/apache2/conf-available/other-vhosts-access-log.conf \
+    /etc/apache2/sites-available/000-default.conf \
+    /etc/apache2/sites-available/default-ssl.conf; \
+  sed -ri -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+    /etc/apache2/apache2.conf; \
+  mkdir /etc/apache2/conf; \
+  echo "IncludeOptional conf/*.conf" > /etc/apache2/sites-available/docker-workdir.conf; \
+  a2ensite docker-workdir
+
+WORKDIR /etc/apache2
+
 EXPOSE 80
 
-ENTRYPOINT ["apache2ctl", "-DFOREGROUND"]
+# Allow loglevel "debug" and "info"
+ENV LOGLEVEL warn
+
+ENTRYPOINT ["apache2ctl", "-DFOREGROUND", "-DLOGLEVEL=$LOGLEVEL"]

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -51,10 +51,7 @@ RUN set -e; \
     /etc/apache2/sites-available/000-default.conf \
     /etc/apache2/sites-available/default-ssl.conf; \
   sed -ri -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-    /etc/apache2/apache2.conf; \
-  mkdir /etc/apache2/conf; \
-  echo "IncludeOptional conf/*.conf" > /etc/apache2/sites-available/docker-workdir.conf; \
-  a2ensite docker-workdir
+    /etc/apache2/apache2.conf
 
 WORKDIR /etc/apache2
 

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -13,29 +13,29 @@ ENV CJOSE_DEB_SHA1 cad77328cf33319e85267a1e9f804912aed3bb5d
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN depsRuntime=" \
-		libcurl3 ca-certificates \
-		libpcre3 \
-		libjansson4 \
-		libhiredis0.10 \
-		apache2-api-20120211 \
-	" \
+    libcurl3 ca-certificates \
+    libpcre3 \
+    libjansson4 \
+    libhiredis0.10 \
+    apache2-api-20120211 \
+  " \
   && depsBuild=" \
-		curl \
-	" \
-	set -x \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $depsRuntime \
-	&& apt-get install -y --no-install-recommends $depsBuild \
-	&& rm -r /var/lib/apt/lists/* \
-	&& curl -SL "$CJOSE_DEB_URL" -o libcjose.deb \
-	&& echo "$CJOSE_DEB_SHA1 libcjose.deb" | sha1sum -c - \
-	&& dpkg -i libcjose.deb \
-	&& rm libcjose.deb \
-	&& curl -SL "$OPENIDC_VERSION_DEB_URL" -o mod_auth_openidc-$OPENIDC_VERSION.deb \
-	&& echo "$OPENIDC_VERSION_DEB_SHA1 mod_auth_openidc-$OPENIDC_VERSION.deb" | sha1sum -c - \
-	&& dpkg -i mod_auth_openidc-$OPENIDC_VERSION.deb \
-	&& rm mod_auth_openidc-$OPENIDC_VERSION.deb \
-	&& ln -s /usr/lib/apache2/modules/mod_auth_openidc.so /usr/local/apache2/modules/mod_auth_openidc.so \
-	&& apt-get purge -y --auto-remove $depsBuild
+    curl \
+  " \
+  set -x \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends $depsRuntime \
+  && apt-get install -y --no-install-recommends $depsBuild \
+  && rm -r /var/lib/apt/lists/* \
+  && curl -SL "$CJOSE_DEB_URL" -o libcjose.deb \
+  && echo "$CJOSE_DEB_SHA1 libcjose.deb" | sha1sum -c - \
+  && dpkg -i libcjose.deb \
+  && rm libcjose.deb \
+  && curl -SL "$OPENIDC_VERSION_DEB_URL" -o mod_auth_openidc-$OPENIDC_VERSION.deb \
+  && echo "$OPENIDC_VERSION_DEB_SHA1 mod_auth_openidc-$OPENIDC_VERSION.deb" | sha1sum -c - \
+  && dpkg -i mod_auth_openidc-$OPENIDC_VERSION.deb \
+  && rm mod_auth_openidc-$OPENIDC_VERSION.deb \
+  && ln -s /usr/lib/apache2/modules/mod_auth_openidc.so /usr/local/apache2/modules/mod_auth_openidc.so \
+  && apt-get purge -y --auto-remove $depsBuild
 
 RUN sed -i 's|LoadModule rewrite_module modules/mod_rewrite.so|LoadModule rewrite_module modules/mod_rewrite.so\nLoadModule auth_openidc_module modules/mod_auth_openidc.so|' conf/httpd.conf

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -57,7 +57,11 @@ WORKDIR /etc/apache2
 
 EXPOSE 80
 
-# Allow loglevel "debug" and "info"
-ENV LOGLEVEL warn
+ENTRYPOINT ["apache2ctl", "-DFOREGROUND"]
 
-ENTRYPOINT ["apache2ctl", "-DFOREGROUND", "-DLOGLEVEL=$LOGLEVEL"]
+RUN set -e; \
+  set -x; \
+  sed -i 's|^LogLevel warn|Include loglevels.conf|' apache2.conf; \
+	for L in warn info debug; do echo "<IfDefine LOGLEVEL=$L>\n  LogLevel $L\n</IfDefine>" >> loglevels.conf; done
+
+CMD ["-DLOGLEVEL=info"]


### PR DESCRIPTION
This was an attempt to go to latest stable and avoid the locally compiled httpd.