### PR TITLE
Use Redis session cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [docker-compose.yml](https://github.com/Reposoft/openidc-keycloak-test/blob/
 Might be run like this:
 ```
 compose="docker-compose -f build-contracts/docker-compose.yml"
-$compose up --build -d postgres keycloak openidc
+$compose up --build -d openidc
 $compose up --build keycloak-setup #TODO
 $compose up --build -d testclient
 $compose logs -f

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ See [docker-compose.yml](https://github.com/Reposoft/openidc-keycloak-test/blob/
 Might be run like this:
 ```
 compose="docker-compose -f build-contracts/docker-compose.yml"
-$compose up --build -d openidc
+$compose up --build -d keycloak openidc
 $compose up --build keycloak-setup #TODO
 $compose up --build -d testclient
 $compose logs -f
+# test session cache
+$compose up -d keycloak openidc2
 ```
 
 Until setup is fully automated see echo:s in [testclient1/keycloak-setup/import.sh](https://github.com/Reposoft/openidc-keycloak-test/blob/keycloak-setup-import/build-contracts/keycloak-setup/import.sh).

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -61,6 +61,16 @@ services:
       - "2080:80"
     volumes:
       - ./html-ajax:/usr/local/apache2/htdocs
+    entrypoint:
+      - /bin/bash
+      - -ce
+      - >
+        sed -i 's|http://openidc/|http://openidc:2080/|' conf/000-default.conf;
+        echo "This instance will test cache sharing when auth happened at the first instance and this one can't reach keycloak";
+        sed -i 's|http://keycloak:8080/|http://keycloak-access-not-allowed-from-instance-2:8080/|' conf/000-default.conf;
+        sed -i "s|ServerName openidc|ServerName openidc\n  ErrorDocument 500 '500: expected if instance 2 sees no session cache, or tries to revalidate'|" conf/000-default.conf;
+        cat conf/000-default.conf | grep 'http://';
+        httpd -DFOREGROUND -DLOGLEVEL=debug
   keycloak-setup:
     build: ./keycloak-setup
     links:

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -31,11 +31,17 @@ services:
     entrypoint:
       - echo
       - "This was just a build job. Exiting."
+  redis:
+    image: redis:4.0.2@sha256:cd277716dbff2c0211c8366687d275d2b53112fecbf9d6c86e9853edb0900956
+    expose:
+      - "6379"
   openidc:
     build: ./openidc
     depends_on:
       - httpd-openidc
+    links:
       - keycloak
+      - redis
     # Don't allow direct communication with keycloak; depends on hosting scenario
     #links:
     #  - keycloak

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -40,18 +40,25 @@ services:
     depends_on:
       - httpd-openidc
     links:
-      - keycloak
-      - redis
-    # Don't allow direct communication with keycloak; depends on hosting scenario
-    #links:
+    # Commented out to disallow direct communication with keycloak; depends on hosting scenario
     #  - keycloak
+      - redis
     expose:
       - "80"
-    # For local browser; you also need "openidc" in your hosts file
     ports:
       - "80:80"
     command:
       - -DLOGLEVEL=info
+    volumes:
+      - ./html-ajax:/usr/local/apache2/htdocs
+  openidc2:
+    build: ./openidc
+    depends_on:
+      - httpd-openidc
+    links:
+      - redis
+    ports:
+      - "2080:80"
     volumes:
       - ./html-ajax:/usr/local/apache2/htdocs
   keycloak-setup:

--- a/build-contracts/html-ajax/protected/index.html
+++ b/build-contracts/html-ajax/protected/index.html
@@ -19,6 +19,7 @@
     <p>If you're running shared state with a second container,
       you're now also authenticated at <a href="http://openidc:2080/protected/">http://openidc:2080/protected/</a>
       without any extra keycloak roundtrips.
+      That is until next revalidation, which :2080 will fail to do: it's intentionally blocked from reaching keycloak.
     </p>
     <!-- page content -->
   </body>

--- a/build-contracts/html-ajax/protected/index.html
+++ b/build-contracts/html-ajax/protected/index.html
@@ -14,11 +14,12 @@
         Log out
       </a>.
     <p>
-    <p>
-      See <a href="cgi/printenv">environment variables</a>
-      and <a href="/protected/redirect_uri?info=json">session info</a>
+    <ul id="log">
+    </ul>
+    <p>If you're running shared state with a second container,
+      you're now also authenticated at <a href="http://openidc:2080/protected/">http://openidc:2080/protected/</a>
+      without any extra keycloak roundtrips.
     </p>
-    <ul id="log"/>
     <!-- page content -->
   </body>
 </html>

--- a/build-contracts/html-ajax/protected/script.js
+++ b/build-contracts/html-ajax/protected/script.js
@@ -1,4 +1,7 @@
 
+// Note that jQuery sends X-Requested-With but other AJAX libs might not
+// so see https://github.com/pingidentity/mod_auth_openidc/wiki/Cookies
+
 var ajaxtestGET = function(log) {
   $.ajax({
     url: '/protected/'

--- a/build-contracts/openidc/000-default.conf
+++ b/build-contracts/openidc/000-default.conf
@@ -30,6 +30,9 @@
 
 	OIDCInfoHook userinfo
 
+	OIDCCacheType redis
+	OIDCRedisCacheServer redis
+
 	# See fast if we accumulate state cookies
 	LimitRequestFieldSize 4096
 


### PR DESCRIPTION
https://github.com/zmartzone/mod_auth_openidc/wiki/Caching#redis is a sensible default for us.

Replaces #3 which failed to validate the setup.

With the `OIDCCacheType` directive commented out from build-contracts/openidc/000-default.conf, an attempt will be made to validate with keycloak, which is blocked through `sed`ed proxy directive:
```
openidc2_1        | [Thu Nov 23 12:34:02.318653 2017] [auth_openidc:debug] [pid 15:tid 139906291406592] src/cache/common.c(603): [client 172.19.0.1:33516] oidc_cache_get: cache miss from shm cache backend for key http://openidc:2080/auth/realms/Testrealm/.well-known/openid-configuration, referer: http://openidc/protected/
openidc2_1        | [Thu Nov 23 12:34:02.318666 2017] [auth_openidc:debug] [pid 15:tid 139906291406592] src/util.c(621): [client 172.19.0.1:33516] oidc_util_http_query_encoded_url: url=http://openidc:2080/auth/realms/Testrealm/.well-known/openid-configuration, referer: http://openidc/protected/
openidc2_1        | [Thu Nov 23 12:34:02.318678 2017] [auth_openidc:debug] [pid 15:tid 139906291406592] src/util.c(662): [client 172.19.0.1:33516] oidc_util_http_call: url=http://openidc:2080/auth/realms/Testrealm/.well-known/openid-configuration, data=(null), content_type=(null), basic_auth=(null), bearer_token=(null), ssl_validate_server=1, timeout=5, outgoing_proxy=(null), pass_cookies=0, ssl_cert=(null), ssl_key=(null), referer: http://openidc/protected/
openidc2_1        | [Thu Nov 23 12:34:02.323597 2017] [auth_openidc:error] [pid 15:tid 139906291406592] [client 172.19.0.1:33516] oidc_util_http_call: curl_easy_perform() failed on: http://openidc:2080/auth/realms/Testrealm/.well-known/openid-configuration (Failed to connect to openidc port 2080: Connection refused), referer: http://openidc/protected/
openidc2_1        | [Thu Nov 23 12:34:02.323781 2017] [auth_openidc:error] [pid 15:tid 139906291406592] [client 172.19.0.1:33516] oidc_provider_static_config: could not retrieve metadata from url: http://openidc:2080/auth/realms/Testrealm/.well-known/openid-configuration, referer: http://openidc/protected/
```

With redis cache, "cache hit":
```
openidc2_1        | [Thu Nov 23 12:38:49.990204 2017] [auth_openidc:debug] [pid 23:tid 140370469910272] src/util.c(2192): [client 172.19.0.1:33572] oidc_util_hdr_in_get: Cookie=mod_auth_openidc_session=be00c911-5a29-4683-a3f4-cb7bf48c49f4, referer: http://openidc:2080/protected/
openidc2_1        | [Thu Nov 23 12:38:49.990211 2017] [auth_openidc:debug] [pid 23:tid 140370469910272] src/util.c(1002): [client 172.19.0.1:33572] oidc_util_get_cookie: returning "mod_auth_openidc_session" = "be00c911-5a29-4683-a3f4-cb7bf48c49f4", referer: http://openidc:2080/protected/
openidc2_1        | [Thu Nov 23 12:38:49.990219 2017] [auth_openidc:debug] [pid 23:tid 140370469910272] src/cache/common.c(567): [client 172.19.0.1:33572] oidc_cache_get: enter: be00c911-5a29-4683-a3f4-cb7bf48c49f4 (section=s, decrypt=1, type=redis), referer: http://openidc:2080/protected/
openidc2_1        | [Thu Nov 23 12:38:49.990529 2017] [auth_openidc:debug] [pid 23:tid 140370469910272] src/cache/common.c(601): [client 172.19.0.1:33572] oidc_cache_get: cache hit: return 4714 bytes from redis cache backend for encrypted key n1UyAqAwnI0NBb1re4O_oSwx2A_qa86hl_Bas9BpKBo, referer: http://openidc:2080/protected/
```